### PR TITLE
close #118 add gateway params to payment redirect api

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Icon Name: acleda
 
 ENV configuration:
 ```ruby
+ENV['PAYWAY_MERCHANT_PROFILE_CONTENT_TYPE'] # html, json
 ENV['PAYWAY_CHECKOUT_PATH']
 ENV['PAYWAY_CHECK_TRANSACTION_PATH']
 ENV['PAYWAY_RETURN_CALLBACK_URL']
@@ -80,6 +81,20 @@ Payment Option: one of the [abapay, cards]
 Merchant: vtenh
 Api Key: xxxxx
 Icon Name: one of the [payway_abapay, payway_cards]
+```
+
+#### Push Back Setting
+
+PayWay will call POST request to return_url when transaction is completed in either form-data or json. By default, its will request with json. If you prefer to use html or form-data format, asks ABA integration team to set the following settings AKA Pushback:
+
+```s
+# push back settings
+Format: html
+```
+
+Make sure to set to env as well to let our system know how to handle when ABA push back.
+```s
+PAYWAY_MERCHANT_PROFILE_CONTENT_TYPE="html"
 ```
 
 ### Note

--- a/app/controllers/spree/webhook/payways_controller.rb
+++ b/app/controllers/spree/webhook/payways_controller.rb
@@ -34,16 +34,16 @@ module Spree
       def request_updater_service
         ::Vpago::Payway::PaymentRequestUpdater
       end
-
+      
+      # the callback invoke by PAYWAY in case of success
       def return_callback_handler(handler_service)
         # pawway send get request with nothing
         if(request.method == "GET")
           return render plain: :ok
         end
 
-        # the callback invoke by PAYWAY in case of success
-        payload = JSON.parse(params[:response])
-        payment = Spree::Payment.find_by(number: payload["tran_id"])
+        builder = Vpago::PaywayReturnOptionsBuilder.new(params: params)
+        payment = builder.payment
 
         request_updater = handler_service.new(payment)
         request_updater.call

--- a/app/serializers/spree/v2/storefront/payment_redirect_serializer.rb
+++ b/app/serializers/spree/v2/storefront/payment_redirect_serializer.rb
@@ -5,7 +5,8 @@ module Spree
         set_type :payment_redirect
 
         attributes :id, :amount, :response_code, :number, :state,
-                   :payment_method_id, :payment_method_name, :redirect_options
+                   :payment_method_id, :payment_method_type, :payment_method_name, 
+                   :redirect_options, :gateway_params, :action_url
       end
     end
   end

--- a/app/services/vpago/payment_redirect_handler.rb
+++ b/app/services/vpago/payment_redirect_handler.rb
@@ -5,7 +5,7 @@ module Vpago
     include ActiveModel::Serialization
 
     attr_accessor :redirect_options, :error_message
-    attr_reader :payment
+    attr_reader :payment, :payment_method_type, :gateway_params, :action_url, :vapgo_checkout_service
 
     delegate      :id, :amount, :response_code, :number, :state,
                   :payment_method_id, :payment_method_name,
@@ -13,6 +13,9 @@ module Vpago
 
     def initialize(payment:)
       @payment = payment
+      @vapgo_checkout_service = payment.payment_method.vapgo_checkout_service.new(payment)
+      @gateway_params = vapgo_checkout_service.gateway_params
+      @action_url = vapgo_checkout_service.action_url
     end
 
     def process
@@ -164,6 +167,10 @@ module Vpago
 
     def payment_method
       @payment.payment_method
+    end
+
+    def payment_method_type
+      payment_method.type
     end
 
     def payment_valid

--- a/app/services/vpago/payway_return_options_builder.rb
+++ b/app/services/vpago/payway_return_options_builder.rb
@@ -1,0 +1,38 @@
+module Vpago
+  class PaywayReturnOptionsBuilder
+    attr_reader :params
+
+    def initialize(params:)
+      @params = params
+    end
+
+    def options
+      if merchant_profile_content_type == 'html'
+        html_params
+      elsif merchant_profile_content_type == 'json'
+        json_params
+      end
+    end
+
+    def payment
+      @payment ||= Spree::Payment.find_by(number: tran_id)
+    end
+
+    def tran_id
+      @tran_id ||= options[:tran_id]
+    end
+
+    def json_params
+      { :tran_id => params[:tran_id] }
+    end
+
+    def html_params
+      payload = JSON.parse(params[:response])
+      { :tran_id => payload["tran_id"] }
+    end
+
+    def merchant_profile_content_type
+      ENV["PAYWAY_MERCHANT_PROFILE_CONTENT_TYPE"].presence || 'html'
+    end
+  end
+end

--- a/lib/vpago/payway_v2/base.rb
+++ b/lib/vpago/payway_v2/base.rb
@@ -71,7 +71,12 @@ module Vpago
         preferred_continue_url = ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL']
         return nil if preferred_continue_url.blank?
 
-        query_string = "tran_id=#{transaction_id}&app_checkout=#{app_checkout}"
+        query_string = {
+          tran_id: transaction_id,
+          app_checkout: app_checkout,
+          order_number: @payment.order.number,
+        }.to_query
+
         preferred_continue_url.index("?") == nil ? "#{preferred_continue_url}?#{query_string}" : "#{preferred_continue_url}&#{query_string}"
       end
 

--- a/lib/vpago/payway_v2/checkout.rb
+++ b/lib/vpago/payway_v2/checkout.rb
@@ -24,6 +24,8 @@ module Vpago
       def checkout_url
         "#{host}#{ENV['PAYWAY_CHECKOUT_PATH']}"
       end
+
+      alias_method :action_url, :checkout_url
     end
   end
 end

--- a/spec/lib/vpago/payway2/base_spec.rb
+++ b/spec/lib/vpago/payway2/base_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Vpago::PaywayV2::Base do
     end
   end
 
-   describe "#last_name" do
+  describe "#last_name" do
     it "return its last_name if there is no spaces surrounding the last_name" do
       bill_address = create(:bill_address, first_name: 'Joe', last_name: 'Ann')
       order = create(:order, billing_address: bill_address)
@@ -41,6 +41,20 @@ RSpec.describe Vpago::PaywayV2::Base do
 
       subject = described_class.new(payment, {})
       expect(subject.last_name).to eq 'Awesome Ann'
+    end
+  end
+
+  describe "#continue_success_url" do
+    it "return continue_success_url with tran_id, app_checkout, order_number, ot (order_token)" do
+      ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
+
+      payment = create(:payway_payment)
+      subject = described_class.new(payment)
+
+      allow(payment).to receive(:number).and_return "PF2IM21Q"
+      allow(payment.order).to receive(:number).and_return "R226226575"
+
+      expect(subject.continue_success_url).to eq 'https://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_number=R226226575&tran_id=PF2IM21Q'
     end
   end
 end

--- a/spec/services/vpago/payway_return_options_builder_spec.rb
+++ b/spec/services/vpago/payway_return_options_builder_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Vpago::PaywayReturnOptionsBuilder do
+  context 'json' do
+    let(:params) {
+      {
+        :tran_id => "PAYKFU1N",
+        :apv => "355207", 
+        :status => 0,
+        :return_params => "{\"tran_id\":\"PAYKFU1N\"}",
+        :controller => "spree/webhook/payways",
+        :action => "v2_return",
+        :payway => {"tran_id"=>"PAYKFU1N", "apv"=>"355207", "status"=>0, "return_params"=>"{\"tran_id\":\"PAYKFU1N\"}"}
+      }
+    }
+
+    subject { described_class.new(params: params) }
+
+    before do
+      allow(subject).to receive(:merchant_profile_content_type).and_return('json')
+    end
+
+    describe '#tran_id' do
+      it 'return correct tran_id base on params' do
+        expect(subject.tran_id).to eq 'PAYKFU1N'
+      end
+    end
+
+    describe '#payment' do
+      it 'return correct payment base on tran_id' do
+        payment = create(:payment, number: 'PAYKFU1N')
+
+        expect(subject.tran_id).to eq 'PAYKFU1N'
+        expect(subject.payment).to eq payment
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Allow payway push back to push within both json & html
- Add order_number to continue_url, so frontend can instantly use it as needed.
- Add gateway_params, and action_url to response to frontend so they can render ABA form.