### PR TITLE
close #119 add request update payment api

### DIFF
--- a/app/models/vpago/order_decorator.rb
+++ b/app/models/vpago/order_decorator.rb
@@ -29,24 +29,6 @@ module Vpago
       consider_risk
     end
 
-    def update_vpago_payments
-      return unless payment?
-
-      payments.each do |payment|
-        next unless payment.is_vpago_type?
-        next if payment.failed?
-
-        payment_method = payment.payment_method
-
-        updater = Vpago::AcledaMobile::PaymentRequestUpdater if payment_method.is_a?(Spree::Gateway::AcledaMobile)
-        updater = Vpago::Acleda::PaymentRequestUpdater if payment_method.is_a?(Spree::Gateway::Acleda)
-        updater = Vpago::PaywayV2::PaymentRequestUpdater if payment_method.is_a?(Spree::Gateway::PaywayV2)
-        updater = Vpago::Payway::PaymentRequestUpdater if payment_method.is_a?(Spree::Gateway::Payway)
-        updater = Vpago::WingSdk::PaymentRequestUpdater if payment_method.is_a?(Spree::Gateway::WingSdk)
-
-        updater.new(payment, skip_on_failed: true).call if updater.present?
-      end
-    end
 
     def send_confirmation_email!
       if !confirmation_delivered? && (paid? || authorized?)

--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -22,6 +22,12 @@ module Vpago
       end
     end
 
+    def request_update
+      updater = payment_method.payment_request_updater.new(self)
+      updater.call
+      updater
+    end
+
     def authorized?
       if source.is_a? Spree::VpagoPaymentSource
         pending?

--- a/app/models/vpago/payment_method_decorator.rb
+++ b/app/models/vpago/payment_method_decorator.rb
@@ -30,6 +30,20 @@ module Vpago
       end
     end
 
+    def payment_request_updater
+      if type_payway?
+        ::Vpago::Payway::PaymentRequestUpdater
+      elsif type_payway_v2?
+        ::Vpago::PaywayV2::PaymentRequestUpdater
+      elsif type_wingsdk?
+        ::Vpago::WingSdk::PaymentRequestUpdater
+      elsif type_acleda?
+        ::Vpago::Acleda::PaymentRequestUpdater
+      elsif type_acleda_mobile?
+        ::Vpago::AcledaMobile::PaymentRequestUpdater 
+      end
+    end
+
     def type_acleda_mobile?
       type == Spree::PaymentMethod::TYPE_ACLEDA_MOBILE
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Spree::Core::Engine.add_routes do
       namespace :storefront do
         resource :checkout, controller: :checkout do
           get :payment_redirect
-          patch :reload_payments
+          patch :request_update_payment
         end
       end
     end

--- a/lib/vpago/acleda/payment_request_updater.rb
+++ b/lib/vpago/acleda/payment_request_updater.rb
@@ -1,13 +1,6 @@
 module Vpago
   module Acleda
-    class PaymentRequestUpdater
-      attr_accessor :payment, :error_message
-
-      def initialize(payment, options={})
-        @payment = payment
-        @options = options
-      end
-
+    class PaymentRequestUpdater < ::Vpago::PaymentRequestUpdater
       def call
         return if @payment.order.paid?
 

--- a/lib/vpago/acleda_mobile/payment_request_updater.rb
+++ b/lib/vpago/acleda_mobile/payment_request_updater.rb
@@ -1,13 +1,6 @@
 module Vpago
   module AcledaMobile
-    class PaymentRequestUpdater
-      attr_accessor :payment, :error_message
-
-      def initialize(payment, options={})
-        @payment = payment
-        @options = options
-      end
-
+    class PaymentRequestUpdater < ::Vpago::PaymentRequestUpdater
       def call
         checker = payment_status_checker
 

--- a/lib/vpago/payment_request_updater.rb
+++ b/lib/vpago/payment_request_updater.rb
@@ -1,0 +1,15 @@
+module Vpago
+  class PaymentRequestUpdater
+    attr_accessor :payment, :error_message
+
+    def initialize(payment, options={})
+      @options = options
+      @payment = payment
+      @error_message = nil
+    end
+
+    def success?
+      @error_message.nil?
+    end
+  end
+end

--- a/lib/vpago/payment_status_marker.rb
+++ b/lib/vpago/payment_status_marker.rb
@@ -7,13 +7,10 @@ module Vpago
       @payment = payment
       @options = options
 
-      @options[:skip_on_failed] = @options[:skip_on_failed] || false
       @options[:status] =  @options[:status] || false
     end
 
     def call
-      return if @options[:skip_on_failed] && !@options[:status]
-
       ActiveRecord::Base.transaction do
         update_payment_source
         update_payment_and_order
@@ -60,7 +57,7 @@ module Vpago
     end
 
     def transition_to_failed!
-      @payment.update_column(:failed, true) if !@payment.failed?
+      @payment.failure! if !@payment.failed?
       @payment.order.update(state: 'payment')
       
       notify_failed_payment

--- a/lib/vpago/payway/payment_request_updater.rb
+++ b/lib/vpago/payway/payment_request_updater.rb
@@ -1,13 +1,6 @@
 module Vpago
   module Payway
-    class PaymentRequestUpdater
-      attr_accessor :payment, :error_message
-
-      def initialize(payment, options={})
-        @options = options
-        @payment = payment
-      end
-
+    class PaymentRequestUpdater < ::Vpago::PaymentRequestUpdater
       def call
         checker = check_payway_status
 
@@ -24,10 +17,6 @@ module Vpago
           marker = ::Vpago::Payway::PaymentStatusMarker.new(@payment, marker_options)
           marker.call
         end
-      end
-
-      def success?
-        @error_message.nil?
       end
 
       private

--- a/lib/vpago/payway_v2/payment_request_updater.rb
+++ b/lib/vpago/payway_v2/payment_request_updater.rb
@@ -1,13 +1,6 @@
 module Vpago
   module PaywayV2
-    class PaymentRequestUpdater
-      attr_accessor :payment, :error_message
-
-      def initialize(payment, options={})
-        @options = options
-        @payment = payment
-      end
-
+    class PaymentRequestUpdater < ::Vpago::PaymentRequestUpdater
       def call
         return if @payment.order.paid?
 
@@ -31,10 +24,6 @@ module Vpago
           marker = ::Vpago::PaymentStatusMarker.new(@payment, marker_options)
           marker.call
         end
-      end
-
-      def success?
-        @error_message.nil?
       end
 
       def check_payway_status

--- a/lib/vpago/wing_sdk/payment_request_updater.rb
+++ b/lib/vpago/wing_sdk/payment_request_updater.rb
@@ -1,13 +1,6 @@
 module Vpago
   module WingSdk
-    class PaymentRequestUpdater
-      attr_accessor :payment, :error_message
-
-      def initialize(payment, options={})
-        @options = options
-        @payment = payment
-      end
-
+    class PaymentRequestUpdater < ::Vpago::PaymentRequestUpdater
       def call
         return if @payment.order.paid?
 
@@ -38,10 +31,6 @@ module Vpago
         return if @payment.present?
 
         @payment = find_payment
-      end
-
-      def success?
-        @error_message.nil?
       end
 
       private


### PR DESCRIPTION
- Removed reload_payments API (just added recently, not need now) [> 116](https://github.com/bookmebus/spree_vpago/pull/116)
- Add request update payment API, this will act like v2_return. But if order already completed, it just response.
- Extract same logics to PaymentRequestUpdater base class.