### PR TITLE
close #124 integrate aba khqr

### DIFF
--- a/app/services/vpago/payment_redirect_handler.rb
+++ b/app/services/vpago/payment_redirect_handler.rb
@@ -59,7 +59,15 @@ module Vpago
 
       @payment.process!
 
-      payment_option == 'abapay' ? process_abapay_v2_deeplink : process_payway_v2_card
+      if payment_option == 'abapay'
+        process_abapay_v2_deeplink
+      elsif payment_option == 'abapay_khqr'
+        # construct web url for render web view.
+        # In web view, it will open intent://ababank.com?... for app to open ABA app.
+        process_payway_v2_card
+      else
+        process_payway_v2_card
+      end
     end
 
     def process_payway_v2_card

--- a/lib/vpago/payway.rb
+++ b/lib/vpago/payway.rb
@@ -1,8 +1,9 @@
 module Vpago
   module Payway
-    CARD_TYPE_ABAPAY = "abapay"
-    CARD_TYPE_CARDS = "cards"
+    CARD_TYPE_ABAPAY = 'abapay'.freeze
+    CARD_TYPE_ABAPAY_KHQR = 'abapay_khqr'.freeze
+    CARD_TYPE_CARDS = 'cards'.freeze
 
-    CARD_TYPES = [CARD_TYPE_ABAPAY, CARD_TYPE_CARDS]
+    CARD_TYPES = [CARD_TYPE_ABAPAY, CARD_TYPE_ABAPAY_KHQR, CARD_TYPE_CARDS].freeze
   end
 end


### PR DESCRIPTION
Integrate ABA khqr is easy as it just use the card flow. 

- One different is that when the app open the URL, that url will render the QR code & open deeplink at the same time.
- The deeplink is sth like 'intent://ababank.com?type=payway&qrcode=000'.
- When our app see it, replace `intent` to `abamobilebank`
  -> abamobilebank://ababank.com?type=payway&qrcode=0002. Then open ABA app as normal.

intent://ababank.com?type=payway&qrcode=000
