### PR TITLE
close #126 integrate alipay wechat

### DIFF
--- a/app/services/vpago/payment_redirect_handler.rb
+++ b/app/services/vpago/payment_redirect_handler.rb
@@ -61,11 +61,12 @@ module Vpago
 
       if payment_option == 'abapay'
         process_abapay_v2_deeplink
-      elsif payment_option == 'abapay_khqr'
-        # construct web url for render web view.
-        # In web view, it will open intent://ababank.com?... for app to open ABA app.
-        process_payway_v2_card
       else
+        # construct web url for render web view.
+        # same implementation for alipay, wechat, cards, abapay_khqr.
+
+        # - for abapay_khqr: in web view, it renders QR then request to open intent://ababank.com?... for app to open ABA app.
+        # - for others: it only renders QR
         process_payway_v2_card
       end
     end

--- a/lib/vpago/payway.rb
+++ b/lib/vpago/payway.rb
@@ -3,7 +3,9 @@ module Vpago
     CARD_TYPE_ABAPAY = 'abapay'.freeze
     CARD_TYPE_ABAPAY_KHQR = 'abapay_khqr'.freeze
     CARD_TYPE_CARDS = 'cards'.freeze
+    CARD_TYPE_WECHAT = 'wechat'.freeze
+    CARD_TYPE_ALIPAY = 'alipay'.freeze
 
-    CARD_TYPES = [CARD_TYPE_ABAPAY, CARD_TYPE_ABAPAY_KHQR, CARD_TYPE_CARDS].freeze
+    CARD_TYPES = [CARD_TYPE_ABAPAY, CARD_TYPE_ABAPAY_KHQR, CARD_TYPE_CARDS, CARD_TYPE_WECHAT, CARD_TYPE_ALIPAY].freeze
   end
 end


### PR DESCRIPTION
No additional changes are needed, when creating alipay or wechat payment method, just set payment_option to `alipay` or `wechat`.

<img src="https://github.com/bookmebus/spree_vpago/assets/29684683/4fc54baa-e95c-4298-9d2a-703cb3b75f57" width="350px" />