### PR TITLE
close #145 acleda payment not process stuck on checkout

### DIFF
--- a/app/services/vpago/payment_redirect_handler.rb
+++ b/app/services/vpago/payment_redirect_handler.rb
@@ -26,6 +26,8 @@ module Vpago
     end
 
     def check_and_process_payment
+      @payment.process!
+
       if payment_method.type_payway_v2?
         process_aba_v2_gateway
       elsif payment_method.type_payway?
@@ -56,8 +58,6 @@ module Vpago
 
     def process_aba_v2_gateway
       payment_option = @payment.payment_method.preferences[:payment_option]
-
-      @payment.process!
 
       if payment_option == 'abapay'
         process_abapay_v2_deeplink
@@ -113,8 +113,6 @@ module Vpago
 
     def process_aba_gateway
       payment_option = @payment.payment_method.preferences[:payment_option]
-
-      @payment.process!
       payment_option == 'abapay' ? process_abapay_deeplink : process_payway_card
     end
 

--- a/spec/services/vpago/payment_redirect_handler_spec.rb
+++ b/spec/services/vpago/payment_redirect_handler_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Vpago::PaymentRedirectHandler do
   let(:gateway) { create(:payway_gateway, auto_capture: true) }
   let(:payment_source) { create(:payway_payment_source, payment_method: gateway) }
   let(:payway_payment) { create(:payway_payment, payment_method: gateway, source: payment_source) }
+  let(:acleda_payment) { create(:acleda_payment) }
 
   let(:general_payment) { create(:payment) }
 
@@ -33,7 +34,9 @@ RSpec.describe Vpago::PaymentRedirectHandler do
         payway_payment.payment_method.preferences[:payment_option] = 'cards'
         handler = Vpago::PaymentRedirectHandler.new(payment: payway_payment)
 
+        expect(payway_payment).to receive(:process!)
         expect(handler).to receive(:process_payway_card)
+
         handler.check_and_process_payment
       end
     end
@@ -43,10 +46,22 @@ RSpec.describe Vpago::PaymentRedirectHandler do
         payway_payment.payment_method.preferences[:payment_option] = 'abapay'
         handler = Vpago::PaymentRedirectHandler.new(payment: payway_payment)
 
+        expect(payway_payment).to receive(:process!)
         expect(handler).to receive(:process_abapay_deeplink)
+
         handler.check_and_process_payment
       end
     end
-    
+
+    context "when payment options is acleda" do
+      it 'processes payment & calls process_acleda_gateway' do
+        handler = Vpago::PaymentRedirectHandler.new(payment: acleda_payment)
+
+        expect(acleda_payment).to receive(:process!)
+        expect(handler).to receive(:process_acleda_gateway)
+
+        handler.check_and_process_payment
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem
Error demo: https://github.com/bookmebus/spree_vpago/issues/145

- Vpago payment except Payway is stay on `checkout` state when it's selected by user in cart. 
- When a Spree::Payment is `checkout` state, Spree::Order considered it as a unprocessed_payments, so when we call order.next, it does not raise gateway error, and lead to moving order state to complete.

## Solution
Above problem can be fixed by call payment.process. I also added process for other vpago payment to avoid this error in future.

## What can we do better?
When the payment state is `checkout` or not in valid state, should raise a gateway error when call order.next. This will make sure order is not moving to completed state.

