### PR TITLE
close #166 support promotion, tax, adjustments in payouts

### DIFF
--- a/app/models/concerns/vpago/payoutable.rb
+++ b/app/models/concerns/vpago/payoutable.rb
@@ -1,0 +1,11 @@
+module Vpago
+  module Payoutable
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :payouts, class_name: 'Spree::Payout', as: :payoutable
+      has_many :confirmed_payouts_for_vendor, -> { confirmed.where(default: false) },
+               class_name: 'Spree::Payout', as: :payoutable
+    end
+  end
+end

--- a/app/models/spree/payout.rb
+++ b/app/models/spree/payout.rb
@@ -1,14 +1,23 @@
 module Spree
   class Payout < Base
+    include Metadata
+
     belongs_to :payout_profile, class_name: 'Spree::PayoutProfile', required: true, inverse_of: :payouts
-    belongs_to :line_item, class_name: 'Spree::LineItem', required: false, inverse_of: :payouts
+    belongs_to :payoutable, required: false, inverse_of: :payouts, polymorphic: true
     belongs_to :payment, class_name: 'Spree::Payment', required: true, inverse_of: :payouts
 
     enum state: { created: 0, confirmed: 1 }
 
-    validates :payout_profile_id, uniqueness: { scope: %i[line_item_id payment_id] }
+    validates :payout_profile_id, uniqueness: { scope: %i[payoutable_type payoutable_id payment_id] }
+
+    delegate :currency, to: :payment
 
     extend DisplayMoney
-    money_methods :amount, :outstanding_amount
+    money_methods :amount, :outstanding_amount,
+                  :amount_owed_to_vendor
+
+    def amount_owed_to_vendor
+      private_metadata&.dig('amount_owed_to_vendor')&.to_f
+    end
   end
 end

--- a/app/models/spree/payout_profile.rb
+++ b/app/models/spree/payout_profile.rb
@@ -6,6 +6,12 @@ module Spree
     has_many :payout_profile_products, class_name: 'Spree::PayoutProfileProduct', inverse_of: :payout_profile
     has_many :products, class_name: 'Spree::Product', through: :payout_profile_products
 
+    has_many :payout_profile_shipping_methods,
+             class_name: 'Spree::PayoutProfileShippingMethod',
+             inverse_of: :payout_profile
+
+    has_many :shipping_methods, class_name: 'Spree::ShippingMethod', through: :payout_profile_shipping_methods
+
     belongs_to :vendor, class_name: 'Spree::Vendor', optional: true, inverse_of: :payout_profiles
 
     validates :type, presence: true

--- a/app/models/spree/payout_profile_product.rb
+++ b/app/models/spree/payout_profile_product.rb
@@ -1,5 +1,8 @@
 module Spree
   class PayoutProfileProduct < Base
+    scope :required, -> { where(optional: false) }
+    scope :optional, -> { where(optional: true) }
+
     belongs_to :payout_profile, class_name: 'Spree::PayoutProfile', inverse_of: :payout_profile_products
     belongs_to :product, class_name: 'Spree::Product', inverse_of: :payout_profile_products
 

--- a/app/models/spree/payout_profile_shipping_method.rb
+++ b/app/models/spree/payout_profile_shipping_method.rb
@@ -1,0 +1,14 @@
+module Spree
+  class PayoutProfileShippingMethod < Base
+    scope :required, -> { where(optional: false) }
+    scope :optional, -> { where(optional: true) }
+
+    belongs_to :payout_profile, class_name: 'Spree::PayoutProfile', inverse_of: :payout_profile_shipping_methods
+    belongs_to :shipping_method, class_name: 'Spree::ShippingMethod', inverse_of: :payout_profile_shipping_methods
+
+    validates :payout_profile, presence: true
+    validates :shipping_method, presence: true
+
+    validates :payout_profile_id, uniqueness: { scope: :shipping_method_id }
+  end
+end

--- a/app/models/vpago/adjustment_decorator.rb
+++ b/app/models/vpago/adjustment_decorator.rb
@@ -1,0 +1,30 @@
+module Vpago
+  module AdjustmentDecorator
+    def self.prepended(base)
+      base.enum handle_by: { store: 0, vendor: 1 }, _prefix: true
+
+      base.scope :handle_by_vendor, -> { eligible.where(handle_by: :vendor) }
+      base.scope :handle_by_store, -> { eligible.where(handle_by: :store) }
+
+      base.before_save :set_handle_by
+
+      def base.total
+        sum(:amount) || 0
+      end
+    end
+
+    private
+
+    def set_handle_by
+      if source.is_a?(::Spree::PromotionAction)
+        self.handle_by = source.run_by
+      elsif source.is_a?(::Spree::TaxRate)
+        self.handle_by = source.tax_category.collect_by
+      end
+    end
+  end
+end
+
+unless Spree::Adjustment.included_modules.include?(Vpago::AdjustmentDecorator)
+  Spree::Adjustment.prepend(Vpago::AdjustmentDecorator)
+end

--- a/app/models/vpago/line_item_decorator.rb
+++ b/app/models/vpago/line_item_decorator.rb
@@ -1,9 +1,7 @@
 module Vpago
   module LineItemDecorator
     def self.prepended(base)
-      base.has_many :payouts, class_name: 'Spree::Payout'
-      base.has_many :confirmed_payouts_for_vendor, -> { confirmed.where(default: false) },
-                    class_name: 'Spree::Payout'
+      base.include ::Vpago::Payoutable
 
       base.has_many :payout_profiles, class_name: 'Spree::PayoutProfile', through: :product
       base.has_many :active_payout_profiles, class_name: 'Spree::PayoutProfile', through: :product
@@ -23,11 +21,50 @@ module Vpago
     end
 
     def commission_amount
-      pre_tax_amount * commission_rate / 100.0
+      vendor_pre_tax_amount * commission_rate / 100.0
     end
 
+    # amount expected to receive by vendor
     def pre_commission_amount
-      pre_tax_amount - commission_amount
+      vendor_pre_tax_amount - commission_amount + vendor_tax_total
+    end
+
+    def vendor_pre_tax_amount
+      subtotal + vendor_adjustments_total_excluding_tax
+    end
+
+    def vendor_tax_total
+      adjustments.tax.handle_by_vendor.total
+    end
+
+    def vendor_adjustments_total_excluding_tax
+      vendor_adjustment = adjustments.non_tax.handle_by_vendor.total
+      order_vendor_adjustment = if order.line_items_count.positive?
+                                  order.adjustments.non_tax.handle_by_vendor.total / order.line_items_count
+                                else
+                                  0
+                                end
+
+      order_vendor_adjustment + vendor_adjustment
+    end
+
+    def latest_private_metadata
+      private_metadata ||= {}
+
+      private_metadata[:subtotal] = subtotal.to_f
+      private_metadata[:commission_rate] = commission_rate.to_f
+      private_metadata[:commission_amount] = commission_amount.to_f
+      private_metadata[:vendor_pre_tax_amount] = vendor_pre_tax_amount.to_f
+      private_metadata[:pre_commission_amount] = pre_commission_amount.to_f
+      private_metadata[:vendor_tax_total] = vendor_tax_total.to_f
+      private_metadata[:vendor_adjustments_total_excluding_tax] = vendor_adjustments_total_excluding_tax.to_f
+
+      private_metadata
+    end
+
+    # generate metadata for financial reports.
+    def update_total_metadata
+      update_column(:private_metadata, latest_private_metadata)
     end
   end
 end

--- a/app/models/vpago/order_decorator.rb
+++ b/app/models/vpago/order_decorator.rb
@@ -3,6 +3,10 @@ module Vpago
     extend Spree::DisplayMoney
     money_methods :order_adjustment_total, :shipping_discount
 
+    def self.prepended(base)
+      base.has_many :payouts, class_name: 'Spree::Payout', through: :payments
+    end
+
     # Make sure the order confirmation is delivered when the order has been paid for.
     def finalize!
       # lock all adjustments (coupon promotions, etc.)
@@ -10,7 +14,7 @@ module Vpago
 
       # update payment and shipment(s) states, and save
       updater.update_payment_state
-      
+
       shipments.each do |shipment|
         shipment.update!(self)
         shipment.finalize! if paid? || authorized?
@@ -22,25 +26,13 @@ module Vpago
 
       touch :completed_at
 
-      if !confirmation_delivered? && (paid? || authorized?)
-        deliver_order_confirmation_email
-      end
+      deliver_order_confirmation_email if !confirmation_delivered? && (paid? || authorized?)
 
       consider_risk
     end
 
-    # currently does not support payout when having adjustment/promotion or having tax.
-    def allowed_payout?
-      return false if adjustment_total > 0
-      return false if included_tax_total > 0
-      return false if additional_tax_total > 0
-      return false if promo_total > 0
-
-      true
-    end
-
     def required_payway_payout?
-      allowed_payout? && line_items.any?(&:required_payway_payout?)
+      line_items.any?(&:required_payway_payout?) || shipments.any?(&:required_payway_payout?)
     end
 
     # override
@@ -48,20 +40,28 @@ module Vpago
       payment_methods = collect_payment_methods(store)
 
       @available_payment_methods ||= if required_payway_payout?
-        payment_methods.select { |payment| payment.type_payway_v2? }
-      else
-        payment_methods
-      end
+                                       payment_methods.select(&:type_payway_v2?)
+                                     else
+                                       payment_methods
+                                     end
+    end
+
+    def line_items_count
+      line_items.size
+    end
+
+    def generate_line_items_total_metadata
+      line_items.each(&:update_total_metadata)
     end
 
     def send_confirmation_email!
-      if !confirmation_delivered? && (paid? || authorized?)
-        deliver_order_confirmation_email
-      end
+      return unless !confirmation_delivered? && (paid? || authorized?)
+
+      deliver_order_confirmation_email
     end
 
     def successful_payment
-      paid? || payments.any? {|p| p.after_pay_method? && p.authorized?}
+      paid? || payments.any? { |p| p.after_pay_method? && p.authorized? }
     end
 
     alias paid_or_authorized? successful_payment
@@ -73,11 +73,10 @@ module Vpago
     def order_adjustment_total
       adjustments.eligible.sum(:amount)
     end
-
-    def has_order_adjustments?
-      order_adjustment_total.abs > 0
-    end
   end
 end
 
-Spree::Order.prepend(Vpago::OrderDecorator)
+if Spree::Order.included_modules.exclude?(Vpago::OrderDecorator)
+  Spree::Order.register_update_hook(:generate_line_items_total_metadata)
+  Spree::Order.prepend(Vpago::OrderDecorator)
+end

--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -2,7 +2,11 @@ module Vpago
   module PaymentDecorator
     def self.prepended(base)
       base.has_many :payouts, class_name: 'Spree::Payout', inverse_of: :payment
-      base.after_create -> { Vpago::PayoutsGenerator.new(self).call }, if: :support_payout?
+      base.after_create -> { Vpago::PayoutsGenerator.new(self).call }, if: :should_generate_payouts?
+    end
+
+    def should_generate_payouts?
+      support_payout? && payouts.empty?
     end
 
     def support_payout?

--- a/app/models/vpago/payouts_generator.rb
+++ b/app/models/vpago/payouts_generator.rb
@@ -1,23 +1,30 @@
 # generate payouts for remaining amount of provided payment.
 module Vpago
   class PayoutsGenerator
-    attr_reader :payment, :line_items
+    attr_reader :payment, :line_items, :shipments
 
     attr_accessor :remaining_amount
 
     def initialize(payment)
       @payment = payment
+
       @line_items = payment.order.line_items.includes(
         :active_payway_payout_profiles,
         :confirmed_payouts_for_vendor,
         :adjustments
       )
 
+      @shipments = payment.order.shipments.includes(
+        :confirmed_payouts_for_vendor,
+        :adjustments,
+        selected_shipping_rate: :active_payway_payout_profiles
+      )
+
       self.remaining_amount = payment.amount
     end
 
     def call
-      payouts = vendor_payouts + store_payouts
+      payouts = vendor_payouts + vendor_shipment_payouts + store_payouts
 
       ActiveRecord::Base.transaction { payouts.each(&:save!) }
     end
@@ -37,11 +44,53 @@ module Vpago
         payouts << Spree::Payout.new(
           default: false,
           state: :created,
-          line_item: line_item,
+          payoutable: line_item,
           payment: payment,
           payout_profile: payout_profile,
           amount: payout_amount,
-          outstanding_amount: outstanding_amount
+          outstanding_amount: outstanding_amount,
+          private_metadata: {
+            total_confirmed_payouts: total_confirmed_payouts,
+            amount_owed_to_vendor: amount_owed_to_vendor,
+            payoutable: line_item.latest_private_metadata
+          }
+        )
+
+        self.remaining_amount -= payout_amount
+      end
+    end
+
+    def vendor_shipment_payouts
+      shipments.each_with_object([]) do |shipment, payouts|
+        next unless shipment.selected_shipping_rate.handle_by_vendor?
+
+        payout_profile = shipment.selected_shipping_rate.active_payway_payout_profiles.first
+        next unless payout_profile.present?
+
+        total_confirmed_payouts = shipment.confirmed_payouts_for_vendor.sum(:amount)
+        next if total_confirmed_payouts >= shipment.cost_with_vendor_adjustment_total
+
+        amount_owed_to_shipping_vendor = shipment.cost_with_vendor_adjustment_total - total_confirmed_payouts
+        payout_amount = [amount_owed_to_shipping_vendor, remaining_amount].min
+        outstanding_amount = [amount_owed_to_shipping_vendor - payout_amount, 0].max
+
+        payouts << Spree::Payout.new(
+          default: false,
+          state: :created,
+          payoutable: shipment,
+          payment: payment,
+          payout_profile: payout_profile,
+          amount: payout_amount,
+          outstanding_amount: outstanding_amount,
+          private_metadata: {
+            total_confirmed_payouts: total_confirmed_payouts,
+            amount_owed_to_vendor: amount_owed_to_shipping_vendor,
+            payoutable: {
+              cost: shipment.cost,
+              vendor_adjustment_total: shipment.vendor_adjustment_total,
+              cost_with_vendor_adjustment_total: shipment.cost_with_vendor_adjustment_total
+            }
+          }
         )
 
         self.remaining_amount -= payout_amount

--- a/app/models/vpago/product_decorator.rb
+++ b/app/models/vpago/product_decorator.rb
@@ -1,18 +1,28 @@
 module Vpago
   module ProductDecorator
     def self.prepended(base)
-      base.scope :required, -> { where(optional: false) }
-      base.scope :optional, -> { where(optional: true) }
+      base.has_many :payout_profile_products,
+                    class_name: 'Spree::PayoutProfileProduct', inverse_of: :product
 
-      base.has_many :payout_profile_products, class_name: 'Spree::PayoutProfileProduct', inverse_of: :product
-      base.has_many :payout_profiles, class_name: 'Spree::PayoutProfile', through: :payout_profile_products, source: :payout_profile
-      
-      base.has_many :active_payout_profiles, -> { verified.active }, class_name: 'Spree::PayoutProfile', through: :payout_profile_products, source: :payout_profile
-      base.has_many :active_payway_payout_profiles, -> { payway.verified.active }, class_name: 'Spree::PayoutProfile', through: :payout_profile_products, source: :payout_profile
+      base.has_many :payout_profiles,
+                    class_name: 'Spree::PayoutProfile', through: :payout_profile_products,
+                    source: :payout_profile
 
-      # required
-      base.has_many :required_payout_profile_products, -> { required }, class_name: 'Spree::PayoutProfileProduct', inverse_of: :product
-      base.has_many :required_active_payout_profiles, -> { verified.active }, class_name: 'Spree::PayoutProfile', through: :payout_profile_products, source: :payout_profile
+      base.has_many :active_payout_profiles, -> { verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :payout_profile_products, source: :payout_profile
+
+      base.has_many :active_payway_payout_profiles, -> { payway.verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :payout_profile_products, source: :payout_profile
+
+      base.has_many :required_payout_profile_products, -> { required },
+                    class_name: 'Spree::PayoutProfileProduct',
+                    inverse_of: :product
+
+      base.has_many :required_active_payout_profiles, -> { verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :required_payout_profile_products, source: :payout_profile
     end
   end
 end

--- a/app/models/vpago/promotion_action_decorator.rb
+++ b/app/models/vpago/promotion_action_decorator.rb
@@ -1,0 +1,11 @@
+module Vpago
+  module PromotionActionDecorator
+    def self.prepended(base)
+      base.enum run_by: { store: 0, vendor: 1 }, _prefix: true
+    end
+  end
+end
+
+unless Spree::PromotionAction.included_modules.include?(Vpago::PromotionActionDecorator)
+  Spree::PromotionAction.prepend(Vpago::PromotionActionDecorator)
+end

--- a/app/models/vpago/shipment_decorator.rb
+++ b/app/models/vpago/shipment_decorator.rb
@@ -1,0 +1,25 @@
+module Vpago
+  module ShipmentDecorator
+    def self.prepended(base)
+      base.include ::Vpago::Payoutable
+    end
+
+    def required_payway_payout?
+      selected_shipping_rate.required_active_payout_profiles.payway.exists?
+    end
+
+    # there is no commission for shipment yet.
+    # so amount that vendor expected is cost + their adjustments.
+    def cost_with_vendor_adjustment_total
+      cost + vendor_adjustment_total
+    end
+
+    def vendor_adjustment_total
+      adjustments.handle_by_vendor.total
+    end
+  end
+end
+
+unless Spree::Shipment.included_modules.include?(Vpago::ShipmentDecorator)
+  Spree::Shipment.prepend(Vpago::ShipmentDecorator)
+end

--- a/app/models/vpago/shipping_method_decorator.rb
+++ b/app/models/vpago/shipping_method_decorator.rb
@@ -1,0 +1,35 @@
+module Vpago
+  module ShippingMethodDecorator
+    def self.prepended(base)
+      base.enum handle_by: { store: 0, vendor: 1 }, _prefix: true
+
+      base.has_many :payout_profile_shipping_methods,
+                    class_name: 'Spree::PayoutProfileShippingMethod',
+                    inverse_of: :shipping_method
+
+      base.has_many :payout_profiles,
+                    class_name: 'Spree::PayoutProfile', through: :payout_profile_shipping_methods,
+                    source: :payout_profile
+
+      base.has_many :active_payout_profiles, -> { verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :payout_profile_shipping_methods, source: :payout_profile
+
+      base.has_many :active_payway_payout_profiles, -> { payway.verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :payout_profile_shipping_methods, source: :payout_profile
+
+      base.has_many :required_payout_profile_shipping_methods, -> { required },
+                    class_name: 'Spree::PayoutProfileShippingMethod',
+                    inverse_of: :shipping_method
+
+      base.has_many :required_active_payout_profiles, -> { verified.active },
+                    class_name: 'Spree::PayoutProfile',
+                    through: :required_payout_profile_shipping_methods, source: :payout_profile
+    end
+  end
+end
+
+unless Spree::ShippingMethod.included_modules.include?(Vpago::ShippingMethodDecorator)
+  Spree::ShippingMethod.prepend(Vpago::ShippingMethodDecorator)
+end

--- a/app/models/vpago/shipping_rate_decorator.rb
+++ b/app/models/vpago/shipping_rate_decorator.rb
@@ -1,0 +1,27 @@
+module Vpago
+  module ShippingRateDecorator
+    def self.prepended(base)
+      base.has_many :payout_profiles, class_name: 'Spree::PayoutProfile', through: :shipping_method
+      base.has_many :active_payout_profiles, class_name: 'Spree::PayoutProfile', through: :shipping_method
+      base.has_many :active_payway_payout_profiles, class_name: 'Spree::PayoutProfile', through: :shipping_method
+      base.has_many :required_active_payout_profiles, class_name: 'Spree::PayoutProfile', through: :shipping_method
+
+      base.enum handle_by: { store: 0, vendor: 1 }, _prefix: true
+
+      base.scope :handle_by_vendor, -> { where(handle_by: :vendor) }
+      base.scope :handle_by_store, -> { where(handle_by: :store) }
+
+      base.before_save :set_handle_by
+    end
+
+    private
+
+    def set_handle_by
+      self.handle_by = shipping_method.handle_by
+    end
+  end
+end
+
+unless Spree::ShippingRate.included_modules.include?(Vpago::ShippingRateDecorator)
+  Spree::ShippingRate.prepend(Vpago::ShippingRateDecorator)
+end

--- a/app/models/vpago/tax_category_decorator.rb
+++ b/app/models/vpago/tax_category_decorator.rb
@@ -1,0 +1,11 @@
+module Vpago
+  module TaxCategoryDecorator
+    def self.prepended(base)
+      base.enum collect_by: { store: 0, vendor: 1 }, _prefix: true
+    end
+  end
+end
+
+unless Spree::TaxCategory.included_modules.include?(Vpago::TaxCategoryDecorator)
+  Spree::TaxCategory.prepend(Vpago::TaxCategoryDecorator)
+end

--- a/db/migrate/20240715091228_create_spree_payouts.rb
+++ b/db/migrate/20240715091228_create_spree_payouts.rb
@@ -1,8 +1,8 @@
 class CreateSpreePayouts < ActiveRecord::Migration[7.0]
   def change
-    create_table :spree_payouts do |t|
+    create_table :spree_payouts, if_not_exists: true do |t|
       t.references :payout_profile, foreign_key: { to_table: :spree_payout_profiles }
-      t.references :line_item, foreign_key: { to_table: :spree_line_items }
+      t.references :payoutable, polymorphic: true, index: true
       t.references :payment, foreign_key: { to_table: :spree_payments }
 
       t.integer :state, default: 0, null: false
@@ -10,6 +10,14 @@ class CreateSpreePayouts < ActiveRecord::Migration[7.0]
 
       t.decimal :outstanding_amount, precision: 10, scale: 2
       t.decimal :amount, precision: 10, scale: 2, default: '0.0', null: false
+
+      if t.respond_to? :jsonb
+        t.jsonb :public_metadata
+        t.jsonb :private_metadata
+      else
+        t.json :public_metadata
+        t.json :private_metadata
+      end
 
       t.timestamps
     end

--- a/db/migrate/20240718195510_create_spree_payout_profile_shipping_methods.rb
+++ b/db/migrate/20240718195510_create_spree_payout_profile_shipping_methods.rb
@@ -1,0 +1,15 @@
+class CreateSpreePayoutProfileShippingMethods < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spree_payout_profile_shipping_methods, if_not_exists: true do |t|
+      t.references :payout_profile, foreign_key: { to_table: :spree_payout_profiles },
+                                    index: { name: 'index_payout_profile_shipping_methods_on_payout_profile_id' }
+
+      t.references :shipping_method, foreign_key: { to_table: :spree_shipping_methods },
+                                     index: { name: 'index_payout_profile_shipping_methods_on_shipping_method_id' }
+
+      t.boolean :optional, null: false, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240718201453_add_handle_by_to_spree_adjustments.rb
+++ b/db/migrate/20240718201453_add_handle_by_to_spree_adjustments.rb
@@ -1,0 +1,5 @@
+class AddHandleByToSpreeAdjustments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_adjustments, :handle_by, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240718201509_add_run_by_to_spree_promotion_actions.rb
+++ b/db/migrate/20240718201509_add_run_by_to_spree_promotion_actions.rb
@@ -1,0 +1,5 @@
+class AddRunByToSpreePromotionActions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_promotion_actions, :run_by, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240718201523_add_collect_by_to_spree_tax_categories.rb
+++ b/db/migrate/20240718201523_add_collect_by_to_spree_tax_categories.rb
@@ -1,0 +1,5 @@
+class AddCollectByToSpreeTaxCategories < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_tax_categories, :collect_by, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240718201538_add_handle_by_to_spree_shipping_method.rb
+++ b/db/migrate/20240718201538_add_handle_by_to_spree_shipping_method.rb
@@ -1,0 +1,5 @@
+class AddHandleByToSpreeShippingMethod < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_shipping_methods, :handle_by, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/db/migrate/20240718201554_add_handle_by_to_spree_shipping_rates.rb
+++ b/db/migrate/20240718201554_add_handle_by_to_spree_shipping_rates.rb
@@ -1,0 +1,5 @@
+class AddHandleByToSpreeShippingRates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :spree_shipping_rates, :handle_by, :integer, null: false, default: 0, if_not_exists: true
+  end
+end

--- a/spec/factories/payout_factory.rb
+++ b/spec/factories/payout_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :payout, class: Spree::Payout do
     payout_profile {|p| p.association(:payway_payout_profile, :random) }
-    line_item {|p| p.association(:line_item) }
+    payoutable {|p| p.association(:line_item) }
     payment {|p| p.association(:payment) }
   end
 end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -47,51 +47,102 @@ RSpec.describe Spree::LineItem, type: :model do
   end
 
   describe '#commission_amount' do
-    let(:vendor) { create(:vendor) }
-    let(:product) { create(:product_in_stock, vendor: vendor) }
-    let(:line_item) { create(:line_item, product: product, price: 100.0) }
+    let(:line_item) { create(:line_item) }
 
-    context 'when product has a commission rate' do
-      it 'caculate 10% of 100 base on product commission rate' do
-        allow(product).to receive(:commission_rate).and_return(10)
+    it 'return subtotal_with_vendor_adjustment_total * commission / 100' do
+      allow(line_item).to receive(:vendor_pre_tax_amount).and_return(70)
+      allow(line_item).to receive(:commission_rate).and_return(10)
 
-        expect(line_item.commission_amount).to eq(10.0)
-      end
-    end
-
-    context 'when product does not have a commission rate but vendor does' do
-      it 'caculate 15% of 100 base on vendor commission rate' do
-        allow(product).to receive(:commission_rate).and_return(nil)
-        vendor.commission_rate = 15
-
-        expect(line_item.commission_amount).to eq(15.0)
-      end
-    end
-
-    context 'when neither product nor vendor has a commission rate' do
-      it 'returns 0 as the commission amount' do
-        allow(product).to receive(:commission_rate).and_return(nil)
-        vendor.commission_rate = nil
-
-        expect(line_item.commission_amount).to eq(0.0)
-      end
+      expect(line_item.commission_amount).to eq(70.0 * 10.0 / 100)
     end
   end
-  
-  describe '#pre_commission_amount' do
-    let(:vendor) { create(:vendor, commission_rate: 10) }
-    let(:product) { create(:product_in_stock, vendor: vendor) }
-    let(:line_item) { create(:line_item, product: product, price: 100.0) }
 
-    it 'return amount before commission cut' do
-      expect(line_item.commission_amount).to eq 10
-      expect(line_item.pre_commission_amount).to eq 90
+  describe '#pre_commission_amount' do
+    let(:line_item) { create(:line_item) }
+
+    it 'return subtotal_with_vendor_adjustment_total - commission_amount + vendor_tax_total' do
+      allow(line_item).to receive(:vendor_pre_tax_amount).and_return(30)
+      allow(line_item).to receive(:commission_amount).and_return(20)
+      allow(line_item).to receive(:vendor_tax_total).and_return(3)
+
+      expect(line_item.pre_commission_amount).to eq(30 - 20 + 3)
+    end
+  end
+
+  describe '#vendor_pre_tax_amount' do
+    let(:line_item) { create(:line_item) }
+
+    it 'return subtotal + vendor_adjustments_total_excluding_tax' do
+      allow(line_item).to receive(:subtotal).and_return(50)
+      allow(line_item).to receive(:vendor_adjustments_total_excluding_tax).and_return(30)
+
+      expect(line_item.pre_commission_amount).to eq(50 + 30)
+    end
+  end
+
+  describe '#vendor_adjustments_total_excluding_tax' do
+    let(:line_item1) { create(:line_item, price: 50) }
+    let(:line_item2) { create(:line_item, price: 50) }
+
+    let!(:order) { create(:order, line_items: [line_item1, line_item2], state: :cart) }
+
+    let(:line_item_promotion_by_vendor_26) { create(:promotion_with_item_adjustment, adjustment_rate: 26) }
+    let(:line_item_promotion_by_store_27) { create(:promotion_with_item_adjustment, adjustment_rate: 27) }
+
+    let(:order_promotion_by_vendor_13) { create(:promotion_with_order_adjustment, weighted_order_adjustment_amount: 13) }
+    let(:order_promotion_by_store_14) { create(:promotion_with_order_adjustment, weighted_order_adjustment_amount: 14) }
+
+    before do
+      order.update_with_updater!
+
+      promotions_run_by_vendor.each { |promotion| promotion.actions.update_all(run_by: :vendor) && promotion.activate(order: order) }
+      promotions_run_by_store.each { |promotion| promotion.actions.update_all(run_by: :store) && promotion.activate(order: order) }
+
+      # make it eligible
+      line_item1.adjustments.update_all(eligible: true)
+      order.adjustments.update_all(eligible: true)
+    end
+
+    context 'when there is promotion that run by vendor' do
+      let(:promotions_run_by_vendor) { [line_item_promotion_by_vendor_26, order_promotion_by_vendor_13] }
+      let(:promotions_run_by_store) { [] }
+  
+      it 'return line item adjustments + order adjustments (order adjustments split to 2 because there are 2 line items)' do
+        expect(line_item1.vendor_adjustments_total_excluding_tax).to eq(-26 - 13.0 / 2)
+      end
+    end
+
+    context 'when there are promotions that run by both vendor & store' do    
+      let(:promotions_run_by_vendor) { [line_item_promotion_by_vendor_26, order_promotion_by_vendor_13] }
+      let(:promotions_run_by_store) { [line_item_promotion_by_store_27, order_promotion_by_store_14] }
+
+      it 'only return line items & order adjustment that run by store' do
+        expect(line_item1.vendor_adjustments_total_excluding_tax).to eq(-26 - 13.0 / 2)
+      end
+    end
+
+    context 'when there are only promotions that run by store' do  
+      let(:promotions_run_by_vendor) { [] }
+      let(:promotions_run_by_store) { [line_item_promotion_by_store_27, order_promotion_by_store_14] }
+  
+      it 'return 0$ adjustment since no promotions that run by vendor' do
+        expect(line_item1.vendor_adjustments_total_excluding_tax).to eq 0
+      end
+    end
+
+    context 'when there are no promotions' do  
+      let(:promotions_run_by_vendor) { [] }
+      let(:promotions_run_by_store) { [] }
+
+      it 'return 0' do
+        expect(line_item1.vendor_adjustments_total_excluding_tax).to eq 0
+      end
     end
   end
 
   describe '#required_payway_payout?' do
     context 'when there are required_active_payout_profiles in product' do
-      let(:payout_product) { build(:payway_payout_profile, active: true, verified_at: DateTime.current)}
+      let(:payout_product) { build(:payway_payout_profile, active: true, verified_at: DateTime.current) }
       let(:product) { create(:product, required_active_payout_profiles: [payout_product]) }
       let(:line_item) { create(:line_item, product: product) }
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -21,80 +21,71 @@ RSpec.describe Spree::Order, type: :model do
     end
   end
 
-  describe '#allowed_payout?' do
-    let(:order) { build(:order) }
+  describe '#generate_line_items_total_metadata' do
+    let(:vendor_a) { create(:vendor, commission_rate: 10) }
+    let(:vendor_b) { create(:vendor, commission_rate: 15) }
 
-    context 'when adjustment_total > 0' do
-      it 'returns false' do
-        order.adjustment_total = 1
-        expect(order.allowed_payout?).to be false
-      end
-    end
-  
-    context 'when included_tax_total > 0' do
-      it 'returns false' do
-        order.included_tax_total = 1
-        expect(order.allowed_payout?).to be false
-      end
-    end
-  
-    context 'when additional_tax_total > 0' do
-      it 'returns false' do
-        order.additional_tax_total = 1
-        expect(order.allowed_payout?).to be false
-      end
-    end
-  
-    context 'when promo_total > 0' do
-      it 'returns false' do
-        order.promo_total = 1
-        expect(order.allowed_payout?).to be false
-      end
-    end
-  
-    context 'when all totals are 0' do
-      it 'returns true' do
-        order.adjustment_total = 0
-        order.included_tax_total = 0
-        order.additional_tax_total = 0
-        order.promo_total = 0
+    let(:product_a) { create(:product_in_stock, vendor: vendor_a) }
+    let(:product_b) { create(:product_in_stock, vendor: vendor_b) }
 
-        expect(order.allowed_payout?).to be true
-      end
+    let(:line_item_a) { create(:line_item, product: product_a) }
+    let(:line_item_b) { create(:line_item, product: product_b) }
+
+    let(:order) { create(:order, line_items: [line_item_a, line_item_b])}
+
+    it 'save commission_rate, commission_amount, pre_commission_amount, subtotal_with_vendor_adjustment_total, vendor_adjustment_total to private_metadata' do
+      expect(line_item_a.private_metadata).to eq({})
+      expect(line_item_b.private_metadata).to eq({})
+
+      order.generate_line_items_total_metadata
+
+      expect(line_item_a.private_metadata).to eq({"commission_amount"=>1.0, "commission_rate"=>10.0, "pre_commission_amount"=>9.0, "subtotal"=>10.0, "vendor_adjustments_total_excluding_tax"=>0.0, "vendor_pre_tax_amount"=>10.0, "vendor_tax_total"=>0.0})
+      expect(line_item_b.private_metadata).to eq({"commission_amount"=>1.5, "commission_rate"=>15.0, "pre_commission_amount"=>8.5, "subtotal"=>10.0, "vendor_adjustments_total_excluding_tax"=>0.0, "vendor_pre_tax_amount"=>10.0, "vendor_tax_total"=>0.0})
     end
   end
 
   describe '#required_payway_payout?' do
-    context 'when allowed_payout is false' do
-      before do
-        order.promo_total = 1
-        expect(order.allowed_payout?).to be false
-      end
+    let(:order) { create(:order_ready_to_ship, line_items_count: 2) }
 
-      it 'return false' do
-        expect(order.required_payway_payout?).to be false
+    before do
+      order.adjustment_total = 0
+      order.included_tax_total = 0
+      order.additional_tax_total = 0
+      order.promo_total = 0
+    end
+
+    context 'when some line items are required payway payout' do
+      it 'return true' do
+        allow(order.line_items[0]).to receive(:required_payway_payout?).and_return(true)
+        allow(order.line_items[1]).to receive(:required_payway_payout?).and_return(false)
+        
+        # true even shipment does not required
+        allow(order.shipments[0]).to receive(:required_payway_payout?).and_return(false)
+
+        expect(order.required_payway_payout?).to be true
       end
     end
 
-    context 'when allowed_payout is true' do
-      let(:line_item_a) { create(:line_item) }
-      let(:line_item_b) { create(:line_item) }
-      let(:order) { create(:order, line_items: [line_item_a, line_item_b])}
-
-      before do
-        order.adjustment_total = 0
-        order.included_tax_total = 0
-        order.additional_tax_total = 0
-        order.promo_total = 0
-
-        expect(order.allowed_payout?).to be true
-      end
-
-      it 'return true when any of line item is required payway payout' do
-        allow(line_item_a).to receive(:required_payway_payout?).and_return(true)
-        allow(line_item_b).to receive(:required_payway_payout?).and_return(false)
+    context 'when some shipments are required payway payout' do
+      it 'return true' do
+        allow(order.shipments[0]).to receive(:required_payway_payout?).and_return(true)
   
+        # true even line items does not required
+        allow(order.line_items[0]).to receive(:required_payway_payout?).and_return(false)
+        allow(order.line_items[1]).to receive(:required_payway_payout?).and_return(false)
+
         expect(order.required_payway_payout?).to be true
+      end
+    end
+
+    context 'when no shipment or line item are required payway payout' do
+      it 'return true' do
+        allow(order.shipments[0]).to receive(:required_payway_payout?).and_return(false)
+  
+        allow(order.line_items[0]).to receive(:required_payway_payout?).and_return(false)
+        allow(order.line_items[1]).to receive(:required_payway_payout?).and_return(false)
+
+        expect(order.required_payway_payout?).to be false
       end
     end
   end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -1,4 +1,40 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Payment, type: :model do
+  let!(:default_payout_profile) { create(:payway_payout_profile, active: true, bank_account_number: '333', default: true, verified_at: DateTime.current)}
+
+  describe "associations" do
+    it { should have_many(:payouts).class_name('Spree::Payout').inverse_of(:payment) }
+  end
+
+  describe 'callback: after_create' do
+    context 'generating payouts' do
+      context 'support payout true' do
+        let(:generator) { Vpago::PayoutsGenerator.new(subject) }
+
+        subject { build(:payway_v2_payment) }
+
+        it 'calls Vpago::PayoutsGenerator' do
+          expect(subject.support_payout?).to be true
+          expect(Vpago::PayoutsGenerator).to receive(:new).with(subject).and_return(generator)
+          expect(generator).to receive(:call).and_call_original   
+
+          subject.save!
+        end
+      end
+
+      context 'support payout false' do
+        let(:generator) { Vpago::PayoutsGenerator.new(subject) }
+
+        subject { build(:payway_payment) }
+
+        it 'does not call Vpago::PayoutsGenerator' do
+          expect(subject.support_payout?).to be false
+          expect(Vpago::PayoutsGenerator).to_not receive(:new).with(subject)
+
+          subject.save!
+        end
+      end
+    end
+  end
 end

--- a/spec/models/spree/payout_profile_shipping_method_spec.rb
+++ b/spec/models/spree/payout_profile_shipping_method_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+RSpec.describe Spree::PayoutProfileShippingMethod, type: :model do
+end

--- a/spec/models/spree/payout_profile_spec.rb
+++ b/spec/models/spree/payout_profile_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Spree::PayoutProfile, type: :model do
   end
 
   describe "associations" do
+    it { should have_many(:payouts).class_name('Spree::Payout').inverse_of(:payout_profile) }
     it { should have_many(:payout_profile_products).class_name('Spree::PayoutProfileProduct').inverse_of(:payout_profile) }
     it { should have_many(:products).class_name('Spree::Product').through(:payout_profile_products) }
     it { should belong_to(:vendor).class_name('Spree::Vendor').optional(true).inverse_of(:payout_profiles) }

--- a/spec/models/spree/payout_spec.rb
+++ b/spec/models/spree/payout_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Spree::Payout, type: :model do
   subject { create(:payout) }
 
   describe "validations" do
-    it { should validate_uniqueness_of(:payout_profile_id).scoped_to([:line_item_id, :payment_id]) }
+    it { should validate_uniqueness_of(:payout_profile_id).scoped_to([:payoutable_type, :payoutable_id, :payment_id]) }
   end
 
   describe "associations" do
     it { should belong_to(:payout_profile).class_name('Spree::PayoutProfile').optional(false).inverse_of(:payouts) }
-    it { should belong_to(:line_item).class_name('Spree::LineItem').optional(true).inverse_of(:payouts) }
+    it { should belong_to(:payoutable).optional(true).inverse_of(:payouts) }
     it { should belong_to(:payment).class_name('Spree::Payment').optional(false).inverse_of(:payouts) }
   end
 end

--- a/spec/models/vpago/payouts_generator_spec.rb
+++ b/spec/models/vpago/payouts_generator_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Vpago::PayoutsGenerator do
   let!(:default_payout_profile) { create(:payway_payout_profile, active: true, bank_account_number: '333', default: true, verified_at: DateTime.current)}
   let(:payout_profile1) { create(:payway_payout_profile, active: true, bank_account_number: '111', verified_at: DateTime.current)}
   let(:payout_profile2) { create(:payway_payout_profile, active: true, bank_account_number: '222', verified_at: DateTime.current)}
+  let(:payout_profile3) { create(:payway_payout_profile, active: true, bank_account_number: '444', verified_at: DateTime.current)}
 
   let(:product0) { create(:product_in_stock, payout_profiles: [payout_profile1]) }
   let(:product1) { create(:product_in_stock, payout_profiles: [payout_profile2]) }
@@ -15,8 +16,25 @@ RSpec.describe Vpago::PayoutsGenerator do
   let(:line_item1) { create(:line_item, price: 6.0, product: product1) }
   let(:line_item2) { create(:line_item, price: 11.0, product: product2) }
 
-  let(:order) { create(:order, line_items: [line_item0, line_item1, line_item2]) }
-  let!(:payment) { create(:payway_v2_payment, order: order, amount: 5.0 + 6.0 + 11.0) }
+  let(:order) { create(:order_with_line_items, shipment_cost: 20, line_items: [line_item0, line_item1, line_item2], without_line_items: true) }
+  let(:shipment) { order.shipments.first }
+
+  let!(:shipping_method) do
+    shipping_method = shipment.shipping_method
+    shipping_method.handle_by = :vendor
+    shipping_method.payout_profiles = [payout_profile3]
+    shipping_method.save
+    shipping_method
+  end
+
+  let!(:shipping_rate) do
+    shipping_rate = shipment.selected_shipping_rate
+    shipping_rate.handle_by = :vendor
+    shipping_rate.save
+    shipping_rate
+  end
+
+  let!(:payment) { create(:payway_v2_payment, order: order, amount: 5.0 + 6.0 + 11.0 + order.shipment_total) }
 
   before do
     # payment auto generate payout, we have to remove it for manully create them again for test.
@@ -26,22 +44,30 @@ RSpec.describe Vpago::PayoutsGenerator do
   subject { described_class.new(payment) }
 
   describe '#call' do
-    it 'generates and saves payouts combine of vendor_payouts & store_payouts' do
+    it 'generates and saves payouts combine of vendor_payouts, vendor_shipment_payouts & store_payouts' do
       expect(subject).to receive(:vendor_payouts).and_call_original
+      expect(subject).to receive(:vendor_shipment_payouts).and_call_original
       expect(subject).to receive(:store_payouts).and_call_original
 
       payouts = subject.call
 
-      expect(payouts.size).to eq 3
+      expect(payouts.size).to eq 4
 
       expect(payouts[0].amount).to eq 5.0
+      expect(payouts[0].payoutable).to eq line_item0
       expect(payouts[0].payout_profile).to eq payout_profile1
 
       expect(payouts[1].amount).to eq 6.0
+      expect(payouts[1].payoutable).to eq line_item1
       expect(payouts[1].payout_profile).to eq payout_profile2
 
-      expect(payouts[2].amount).to eq 11.0
-      expect(payouts[2].payout_profile).to eq default_payout_profile
+      expect(payouts[2].amount).to eq order.shipment_total
+      expect(payouts[2].payoutable).to eq shipment
+      expect(payouts[2].payout_profile).to eq payout_profile3
+
+      expect(payouts[3].amount).to eq 11.0
+      expect(payouts[3].payoutable).to eq nil
+      expect(payouts[3].payout_profile).to eq default_payout_profile
     end
   end
 
@@ -58,11 +84,11 @@ RSpec.describe Vpago::PayoutsGenerator do
         expect(vendor_payouts.size).to eq 2
 
         expect(line_item0.payout_profiles.size).to eq 1
-        expect(vendor_payouts[0].line_item_id).to eq line_item0.id
+        expect(vendor_payouts[0].payoutable).to eq line_item0
         expect(vendor_payouts[0].amount).to eq(5.0)
 
         expect(line_item1.payout_profiles.size).to eq 1
-        expect(vendor_payouts[1].line_item_id).to eq line_item1.id
+        expect(vendor_payouts[1].payoutable).to eq line_item1
         expect(vendor_payouts[1].amount).to eq(6.0)
 
         # line_item_2 does not have payout profiles, so we don't build them in vendor_payouts.
@@ -76,19 +102,60 @@ RSpec.describe Vpago::PayoutsGenerator do
         # payment auto generate payout, we have to remove it for manully create them again for test.
         Spree::Payout.destroy_all
 
-        create(:payout, state: :confirmed, amount: 1, line_item: line_item0)
-        create(:payout, state: :confirmed, amount: 2, line_item: line_item1)
+        create(:payout, state: :confirmed, amount: 1, payoutable: line_item0)
+        create(:payout, state: :confirmed, amount: 2, payoutable: line_item1)
       end
 
       it 'build vendor payouts with only amount that remain from previous payouts' do
         vendor_payouts = subject.vendor_payouts
 
         expect(vendor_payouts.size).to eq 2
-        expect(vendor_payouts[0].line_item_id).to eq line_item0.id
+        expect(vendor_payouts[0].id).to eq nil
+        expect(vendor_payouts[0].payoutable).to eq line_item0
         expect(vendor_payouts[0].amount).to eq(5.0 - 1)
 
-        expect(vendor_payouts[1].line_item_id).to eq line_item1.id
+        expect(vendor_payouts[1].payoutable).to eq line_item1
         expect(vendor_payouts[1].amount).to eq(6.0 - 2)
+      end
+    end
+  end
+
+  describe '#vendor_shipment_payouts' do
+    context 'when does not have confirmed_payouts for shipment in previous payments' do
+      before do
+        # payment auto generate payout, we have to remove it for manully create them again for test.
+        Spree::Payout.destroy_all
+      end
+
+      it 'build payouts for all required amount' do
+        vendor_shipment_payouts = subject.vendor_shipment_payouts
+
+        expect(vendor_shipment_payouts.size).to eq 1
+        expect(vendor_shipment_payouts[0].id).to eq nil
+        expect(vendor_shipment_payouts[0].payout_profile).to eq payout_profile3
+        expect(vendor_shipment_payouts[0].payoutable).to eq shipment
+
+        expect(shipment.cost).to eq 20
+        expect(vendor_shipment_payouts[0].amount).to eq 20
+      end
+    end
+
+    context 'when have confirmed_payouts in previous payments' do
+      before do
+        # payment auto generate payout, we have to remove it for manully create them again for test.
+        Spree::Payout.destroy_all
+
+        create(:payout, state: :confirmed, amount: 3, payoutable: shipment)
+      end
+
+      it 'build payouts with only amount that remain from previous payouts' do
+        vendor_shipment_payouts = subject.vendor_shipment_payouts
+
+        expect(vendor_shipment_payouts.size).to eq 1
+        expect(vendor_shipment_payouts[0].id).to eq nil
+        expect(vendor_shipment_payouts[0].payout_profile).to eq payout_profile3
+        expect(vendor_shipment_payouts[0].payoutable).to eq shipment
+        expect(vendor_shipment_payouts[0].amount).to eq shipment.cost - 3
       end
     end
   end


### PR DESCRIPTION
## I. Why?

In previous payout implementations, we disabled payouts when the order had promotions, adjustments, taxes, etc. This PR is intended to support them.

To support all types of adjustments, we need to understand who is running those adjustments to calculate the correct commission and exact money that merchant expect for each of their products. We want to automate the process as much as possible.

Example:

- When the promotion is run by the merchant:
  If the item is 50$ with 10% promotion run by the merchant, user will pay 45$. We can safely send that 45$ to the merchant since 45$ is what merchant expect.
- In another case when the promotion is run by the store (us):
  If the item is 50$ with 10% promotion run by the store, user will also pay 45$, but the merchant expected 50$. In this case, we can only send 45$ to the merchant and record the remaining $5 as an outstanding balance, which we (the store) will cover. After recorded, we can clear this amount later.

## II. Table Design
This is the database designed to support the above use cases & records all financial data. 
| |
| - |
| How payout is setup? |
| ![payout - how to setup](https://github.com/user-attachments/assets/0df5a205-888b-42c6-a1a1-da90d798a73d)
| How payout is generated? |
| ![payout - how payout is generated_](https://github.com/user-attachments/assets/ebc9a85a-3113-4711-ba77-bc74b1675852) |

## III. Test with use cases

### 1. `Use case #1`
![payout - usecase 1](https://github.com/user-attachments/assets/c874a1be-1f28-472b-a624-cdeb049300ef)

### 2. `Use case #2`
![payout - usecase 2](https://github.com/user-attachments/assets/064799a3-18eb-46ae-b45e-ef4a307c9a33)

### 3. `Use case #3`
![payout - usecase 3](https://github.com/user-attachments/assets/7cb0d2ae-5cdc-4047-a35b-858d75e51009)

### 4. `Use case #4`
![payout - usecase 4](https://github.com/user-attachments/assets/8b784832-753f-4c80-b598-7fe2b910669a)

### 5. `Use case #5`
![payout - usecase 5](https://github.com/user-attachments/assets/1b639334-965a-469b-9628-3268ee9c202b)

### 6. `Use case #6`
![payout - usecase 6](https://github.com/user-attachments/assets/53c8d298-cd40-45d2-bc4f-9114141c0816)

## Related PR (UI for this changes):
- https://github.com/bookmebus/spree_vpago/pull/169