### PR TITLE
close #178 allow vendor to have their own payment methods

### DIFF
--- a/app/controllers/spree/admin/payment_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/payment_methods_controller_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  module Admin
+    module PaymentMethodsControllerDecorator
+      def scope
+        scope = current_store.payment_methods_including_vendor.accessible_by(current_ability, :index)
+        scope = scope.where.not(vendor_id: nil) if params[:tab] == 'vendors'
+        scope
+      end
+    end
+  end
+end
+
+Spree::Admin::PaymentMethodsController.prepend(Spree::Admin::PaymentMethodsControllerDecorator)

--- a/app/models/vpago/line_item_decorator.rb
+++ b/app/models/vpago/line_item_decorator.rb
@@ -8,6 +8,9 @@ module Vpago
       base.has_many :active_payway_payout_profiles, class_name: 'Spree::PayoutProfile', through: :product
 
       base.has_many :required_active_payout_profiles, class_name: 'Spree::PayoutProfile', through: :product
+
+      base.has_one :vendor, through: :variant
+      base.has_many :vendor_payment_methods, class_name: 'Spree::PaymentMethod', through: :variant
     end
 
     # considred required when there are any required profiles.
@@ -69,4 +72,4 @@ module Vpago
   end
 end
 
-Spree::LineItem.prepend(Vpago::LineItemDecorator)
+Spree::LineItem.prepend(Vpago::LineItemDecorator) if Spree::LineItem.included_modules.exclude?(Vpago::LineItemDecorator)

--- a/app/models/vpago/order_decorator.rb
+++ b/app/models/vpago/order_decorator.rb
@@ -5,6 +5,24 @@ module Vpago
 
     def self.prepended(base)
       base.has_many :payouts, class_name: 'Spree::Payout', through: :payments
+      base.has_many :vendor_payment_methods, -> { unscope(:order).distinct },
+                    class_name: 'Spree::PaymentMethod',
+                    through: :line_items
+
+      base.state_machine.before_transition from: :cart, do: :ensure_valid_vendor_payment_methods
+    end
+
+    def ensure_valid_vendor_payment_methods
+      return if line_items_from_same_vendor?
+      return unless vendor_payment_methods.any?
+
+      errors.add(:line_items, 'some_payment_methods_cant_be_used_across_vendors')
+
+      false
+    end
+
+    def line_items_from_same_vendor?
+      line_items.joins(:variant).pluck('spree_variants.vendor_id').uniq.size == 1
     end
 
     # Make sure the order confirmation is delivered when the order has been paid for.
@@ -37,7 +55,11 @@ module Vpago
 
     # override
     def available_payment_methods(store = nil)
-      payment_methods = collect_payment_methods(store)
+      payment_methods = if vendor_payment_methods.any?
+                          vendor_payment_methods
+                        else
+                          collect_payment_methods(store)
+                        end
 
       @available_payment_methods ||= if required_payway_payout?
                                        payment_methods.select(&:type_payway_v2?)

--- a/app/models/vpago/payment_method_decorator.rb
+++ b/app/models/vpago/payment_method_decorator.rb
@@ -8,6 +8,7 @@ module Vpago
 
     def self.prepended(base)
       base.preference :icon_name, :string, default: 'cheque'
+      base.belongs_to :vendor, class_name: 'Spree::Vendor', optional: true, inverse_of: :payment_methods
 
       def base.vpago_payments
         [

--- a/app/models/vpago/store_decorator.rb
+++ b/app/models/vpago/store_decorator.rb
@@ -1,0 +1,17 @@
+module Vpago
+  module StoreDecorator
+    def self.prepended(base)
+      # override
+      base.has_many :payment_methods, -> { where(vendor_id: nil) },
+                    through: :store_payment_methods,
+                    class_name: 'Spree::PaymentMethod'
+
+      base.has_many :payment_methods_including_vendor,
+                    through: :store_payment_methods,
+                    class_name: 'Spree::PaymentMethod',
+                    source: :payment_method
+    end
+  end
+end
+
+Spree::Store.prepend(Vpago::StoreDecorator) unless Spree::Store.included_modules.include?(Vpago::StoreDecorator)

--- a/app/models/vpago/variant_decorator.rb
+++ b/app/models/vpago/variant_decorator.rb
@@ -1,0 +1,22 @@
+module Vpago
+  module VariantDecorator
+    def self.prepended(base)
+      base.belongs_to :vendor, class_name: 'Spree::Vendor'
+
+      base.has_many :vendor_payment_methods, class_name: 'Spree::PaymentMethod',
+                                             through: :vendor,
+                                             source: :payment_methods
+    end
+  end
+end
+
+if Spree::Variant.included_modules.exclude?(Vpago::VariantDecorator)
+  # spree_multi_vendor use :vendor method for assoication, we should use association (belongs_to :vendor) instead.
+  #
+  # problem with those methods is that it store value in memeory,
+  # even we call variant.reload, the method value is no being reload.
+  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor
+  SpreeMultiVendor::Spree::VariantDecorator.remove_method :vendor_id
+
+  Spree::Variant.prepend(Vpago::VariantDecorator)
+end

--- a/app/models/vpago/vendor_decorator.rb
+++ b/app/models/vpago/vendor_decorator.rb
@@ -2,6 +2,7 @@ module Vpago
   module VendorDecorator
     def self.prepended(base)
       base.has_many :payout_profiles, class_name: 'Spree::PayoutProfile', inverse_of: :vendor
+      base.has_many :payment_methods, class_name: 'Spree::PaymentMethod', inverse_of: :vendor
     end
   end
 end

--- a/app/overrides/spree/admin/payment_methods/_form/vendor_field.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/_form/vendor_field.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- insert_before "[data-hook='display']" -->
+
+<div data-hook="vendor" class="form-group">
+  <%= label_tag :payment_method_vendor, Spree.t(:vendor) %>
+  <%= collection_select(:payment_method, :vendor_id, Spree::Vendor.all, :id, :name, { include_blank: Spree.t('match_choices.none') }, { class: 'select2' }) %>
+</div>

--- a/app/overrides/spree/admin/payment_methods/index/payment_methods_tabs.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/index/payment_methods_tabs.html.erb.deface
@@ -1,0 +1,9 @@
+<!-- insert_before "erb[silent]:contains('content_for :page_actions')" -->
+
+<%= render partial: 'spree/admin/shared/payment_methods_tabs' %>
+
+<% if params[:tab] == 'vendors' %>
+  <div class="alert alert-info mb-3">
+    <%= svg_icon name: "info-circle.svg", classes: 'mr-2', width: '16', height: '16' %> Payment methods for each vendor. Once set, only those payment methods will be displayed to user.
+  </div>
+<% end %>

--- a/app/overrides/spree/admin/payment_methods/index/vendor_body.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/index/vendor_body.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_before "[data-hook='admin_payment_methods_index_row_actions']" -->
+
+<% if params[:tab] == 'vendors' %>
+  <td class="text-center"><%= method.vendor&.name || 'N/A' %></td>
+<% end %>

--- a/app/overrides/spree/admin/payment_methods/index/vendor_header.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/index/vendor_header.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- insert_before "[data-hook='admin_payment_methods_index_header_actions']" -->
+
+<% if params[:tab] == 'vendors' %>
+  <th class="text-center"><%= Spree.t(:vendor) %></th>
+<% end %>

--- a/app/views/spree/admin/shared/_payment_methods_tabs.html.erb
+++ b/app/views/spree/admin/shared/_payment_methods_tabs.html.erb
@@ -1,0 +1,15 @@
+<% content_for(:page_tabs) do %>
+  <%= content_tag :li, class: 'nav-item' do %>
+    <%= link_to_with_icon 'building.svg',
+      Spree::Store.default&.name || Spree.t(:store),
+      admin_payment_methods_url,
+      class: "nav-link #{'active' if params[:tab].blank? }" %>
+  <% end if can?(:admin, Spree::PaymentMethod) %>
+
+  <%= content_tag :li, class: 'nav-item' do %>
+    <%= link_to_with_icon 'store.svg',
+      Spree.t(:vendors),
+      admin_payment_methods_url(tab: :vendors),
+      class: "nav-link #{'active' if params[:tab] == 'vendors' }" %>
+  <% end if can?(:admin, Spree::PaymentMethod) %>
+<% end %>

--- a/db/migrate/20240808102853_add_vendor_reference_to_spree_payment_methods.rb
+++ b/db/migrate/20240808102853_add_vendor_reference_to_spree_payment_methods.rb
@@ -1,0 +1,7 @@
+class AddVendorReferenceToSpreePaymentMethods < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :spree_payment_methods, :vendor,
+                  index: true, foreign_key: { to_table: :spree_vendors },
+                  if_not_exists: true
+  end
+end

--- a/lib/generators/spree_vpago/install/install_generator.rb
+++ b/lib/generators/spree_vpago/install/install_generator.rb
@@ -5,6 +5,7 @@ module SpreeVpago
       source_root File.expand_path('templates', __dir__)
 
       def add_migrations
+        run 'bundle exec rake railties:install:migrations FROM=spree_multi_vendor'
         run 'bundle exec rake railties:install:migrations FROM=spree_vpago'
       end
 

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -10,6 +10,57 @@ RSpec.describe Spree::Order, type: :model do
     create(:payway_payment, payment_method: gateway, source: payment_source, order: order, amount: order.total, state: 'completed') 
   }
 
+  context 'state machine' do
+    context 'before transition cart -> any' do
+      describe 'callback: ensure_valid_vendor_payment_methods' do
+        let(:vendor1) { create(:vendor) }
+        let(:vendor2) { create(:vendor) }
+    
+        let!(:vendor1_line_item1) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1)) }
+        let!(:vendor1_line_item2) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1)) }
+
+        let!(:vendor2_line_item1) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor2)) }
+        let!(:vendor2_line_item2) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor2)) }
+
+        context 'when line items from same vendor' do
+          it 'does not return any error' do
+            payment_method1 = create(:payment_method, vendor: vendor1)
+            order = create(:order, state: :cart, line_items: [vendor1_line_item1, vendor1_line_item2])
+
+            expect(order.line_items_from_same_vendor?).to be true
+            expect(order.next).to be true
+            expect(order.state).to eq 'address'
+          end
+        end
+
+        context 'when line items from different vendor & each line item has no payment_methods' do
+          it 'does not return any error' do
+            order = create(:order, state: :cart, line_items: [vendor1_line_item1, vendor2_line_item1])
+
+            expect(order.line_items_from_same_vendor?).to be false
+            expect(order.vendor_payment_methods.size).to eq 0
+            expect(order.next).to be true
+            expect(order.state).to eq 'address'
+          end
+        end
+
+        context 'when line items from different vendor & some line items has their own payment_methods' do
+          it 'return error & keep order.state the same' do
+            payment_method1 = create(:payment_method, vendor: vendor1)
+            order = create(:order, state: :cart, line_items: [vendor1_line_item1, vendor2_line_item2])
+  
+            expect(order.line_items_from_same_vendor?).to be false
+            expect(order.vendor_payment_methods.size).to eq 1
+
+            expect(order.next).to be false
+            expect(order.state).to eq 'cart'
+            expect(order.errors.messages).to include(line_items: include('some_payment_methods_cant_be_used_across_vendors'))
+          end
+        end
+      end
+    end
+  end
+
   context '#cancel' do
     it 'marks the payway to void' do
       allow_any_instance_of(Spree::Shipment).to receive(:refresh_rates).and_return(true)
@@ -18,6 +69,55 @@ RSpec.describe Spree::Order, type: :model do
       order.reload
 
       expect(order.payments.first).to be_void
+    end
+  end
+
+  describe '#line_items_from_same_vendor?' do
+    let(:vendor1) { create(:vendor) }
+    let(:vendor2) { create(:vendor) }
+    let(:order) { create(:order) }
+
+    it 'return true when line item from same vendor' do
+      line_item1 = create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1))
+      line_item2 = create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1))
+      order.reload
+
+      expect(order.line_items.size).to eq 2
+      expect(order.line_items_from_same_vendor?).to be true
+    end
+
+    it 'return false when line item from different vendor' do
+      line_item1 = create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1))
+      line_item2 = create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor2))
+      order.reload
+
+      expect(order.line_items.size).to eq 2
+      expect(order.line_items_from_same_vendor?).to be false
+    end
+  end
+
+  describe '#available_payment_methods' do
+    let(:vendor1) { create(:vendor) }
+    let(:vendor2) { create(:vendor) }
+
+    let(:order) { create(:order) }
+
+    let!(:line_item1) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor1)) }
+    let!(:line_item2) { create(:line_item, order: order, product: create(:product_in_stock, vendor: vendor2)) }
+
+    context 'when have vendor payment methods in line items' do
+      let!(:payment_method0) { create(:payment_method) }
+      let!(:payment_method1) { create(:payment_method, vendor: vendor1) }
+      let!(:payment_method2) { create(:payment_method, vendor: vendor2) }
+
+      it 'return all payment methods associated with line items vendor' do
+        expect(order.available_payment_methods.size).to eq 2
+        expect(order.available_payment_methods.pluck(:id)).to eq [payment_method1.id, payment_method2.id]
+      end
+
+      it 'return does not return any store payment methods (has no associated vendor)' do
+        expect(order.available_payment_methods.pluck(:id)).not_to include(payment_method0.id)
+      end
     end
   end
 


### PR DESCRIPTION
Allow vendor to have their own payment method.

| |
| - | 
| ![image1](https://github.com/user-attachments/assets/3e7efa7a-aae0-4664-86fc-1fa174b250d6) |
| ![image2](https://github.com/user-attachments/assets/3ef796aa-c867-488c-a9b1-12759e89012e) |
| ![image3](https://github.com/user-attachments/assets/c45c87aa-5f7d-4919-8ee7-87e88a869ded) |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/8bfdcd2d-4324-4ad1-bdff-0a78b80308ed"> |

Note: See More button on mobile UI just a bug (we'll fix it on cm-market-app soon)
