### PR TITLE
close #182 add return deeplink

### DIFF
--- a/app/models/spree/gateway/payway_v2.rb
+++ b/app/models/spree/gateway/payway_v2.rb
@@ -7,6 +7,7 @@ module Spree
     preference :api_key, :string
     preference :merchant_id, :string
     preference :payment_option, :string # 'abapay', 'cards', 'abapay_deeplink'
+    preference :deeplink_scheme, :string # eg. 'bookmeplus', 'vtenh'
     preference :transaction_fee_fix, :string
     preference :transaction_fee_percentage, :string
 
@@ -24,7 +25,7 @@ module Spree
     end
 
     def card_type
-      Vpago::Payway::CARD_TYPES.index(preferences[:payment_option]) == nil ? Vpago::Payway::CARD_TYPE_ABAPAY : preferences[:payment_option]
+      Vpago::Payway::CARD_TYPES.index(preferences[:payment_option]).nil? ? Vpago::Payway::CARD_TYPE_ABAPAY : preferences[:payment_option]
     end
 
     def is_card?
@@ -37,7 +38,7 @@ module Spree
 
     # partial to render the gateway.
     def method_type
-      "payway_v2"
+      'payway_v2'
     end
 
     def available_for_order?(_order)
@@ -55,21 +56,19 @@ module Spree
       true
     end
 
-    def process(money, source, gateway_options)
-      Rails.logger.debug{"About to create payment for order #{gateway_options[:order_id]}"}
+    def process(_money, _source, gateway_options)
+      Rails.logger.debug { "About to create payment for order #{gateway_options[:order_id]}" }
       # First of all, invalidate all previous tranx orders to prevent multiple paid orders
       # source.save!
       ActiveMerchant::Billing::Response.new(true, 'Order created')
     end
 
-    def cancel(response_code)
+    def cancel(_response_code)
       # we can use this to send request to payment gateway api to cancel the payment ( void )
       # currently Payway does not support to cancel the gateway
-      
+
       # in our case don't do anything
       ActiveMerchant::Billing::Response.new(true, 'Payway order has been cancelled.')
     end
-
   end
-
 end

--- a/lib/vpago/payway_v2/base.rb
+++ b/lib/vpago/payway_v2/base.rb
@@ -117,6 +117,22 @@ module Vpago
         end
       end
 
+      def return_deeplink_url
+        scheme = @payment.payment_method.preferences[:deeplink_scheme]
+        return nil unless scheme.present?
+        return nil unless continue_success_url.present?
+
+        uri = URI.parse(continue_success_url)
+        uri.scheme = scheme
+        uri.to_s
+      end
+
+      def return_deeplink
+        return nil unless return_deeplink_url.present?
+
+        Base64.strict_encode64({ android_scheme: return_deeplink_url, ios_scheme: return_deeplink_url }.to_json)
+      end
+
       def hash_hmac
         hash = Base64.strict_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha512'), api_key, hash_data))
 
@@ -127,7 +143,13 @@ module Vpago
       end
 
       def hash_data
-        result = "#{req_time}#{merchant_id}#{transaction_id}#{amount}#{first_name}#{last_name}#{email}#{phone}#{payment_option}#{return_url}#{continue_success_url}#{return_params}"
+        result = "#{req_time}#{merchant_id}#{transaction_id}#{amount}#{first_name}#{last_name}#{email}#{phone}"
+
+        result += payment_option if payment_option.present?
+        result += return_url if return_url.present?
+        result += continue_success_url if continue_success_url.present?
+        result += return_deeplink if return_deeplink.present?
+        result += return_params if return_params.present?
         result += payout if payout.present?
 
         log_hash_data = "Hash data: #{result}"

--- a/lib/vpago/payway_v2/checkout.rb
+++ b/lib/vpago/payway_v2/checkout.rb
@@ -18,16 +18,17 @@ module Vpago
           hash: hash_hmac
         }
 
+        result[:return_deeplink] = return_deeplink unless return_deeplink.nil?
         result[:view_type] = view_type unless view_type.nil?
         result[:payout] = payout unless payout.nil?
         result
       end
 
       def checkout_url
-        "#{host}#{ENV['PAYWAY_CHECKOUT_PATH']}"
+        "#{host}#{ENV.fetch('PAYWAY_CHECKOUT_PATH', nil)}"
       end
 
-      alias_method :action_url, :checkout_url
+      alias action_url checkout_url
     end
   end
 end

--- a/spec/lib/vpago/payway_v2/base_spec.rb
+++ b/spec/lib/vpago/payway_v2/base_spec.rb
@@ -59,6 +59,87 @@ RSpec.describe Vpago::PaywayV2::Base do
     end
   end
 
+  describe "#return_deeplink_url" do
+    subject { described_class.new(payment) }
+
+    context 'when continue_callback_url is not present' do
+      let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      it "return nil (because deeplink url base on continue_url)" do
+        ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = nil
+
+        expect(subject.continue_success_url).to eq nil
+        expect(subject.return_deeplink_url).to eq nil
+      end
+    end
+
+    context 'when preferred_deeplink_scheme is not present' do
+      let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: nil) }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      it "return nil" do
+        ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
+
+        expect(subject.return_deeplink_url).to eq nil
+      end
+    end
+
+    context 'when continue_callback_url & preferred_deeplink_scheme is present' do
+      let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      it "return return_deeplink url" do
+        ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
+
+        allow(payment).to receive(:number).and_return "PF2IM21Q"
+        allow(payment.order).to receive(:number).and_return "R226226575"
+  
+        expect(subject.return_deeplink_url).to eq 'bookmeplus://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
+      end
+    end
+  end
+
+  describe "#subject.return_deeplink" do
+    context 'when return_deeplink_url is not present?' do
+      let(:method) { create(:payway_v2_gateway) }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      subject { described_class.new(payment) }
+
+      it 'return nil' do
+        expect(subject.return_deeplink_url).to eq nil
+        expect(subject.return_deeplink).to eq nil
+      end
+    end
+
+    context 'when return_deeplink_url is present?' do
+      let(:payment) { create(:payway_v2_payment) }
+
+      subject { described_class.new(payment) }
+
+      it 'return encoded base 64 of android / ios deeplink' do
+        allow(subject).to receive(:return_deeplink_url).and_return 'bookmeplus://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
+
+        expect(subject.return_deeplink).to eq Base64.strict_encode64({ android_scheme: subject.return_deeplink_url, ios_scheme: subject.return_deeplink_url }.to_json)
+        expect(subject.return_deeplink).to eq "eyJhbmRyb2lkX3NjaGVtZSI6ImJvb2ttZXBsdXM6Ly9jb250aWdvLmFzaWEvd2ViaG9vay9wYXl3YXlzL3YyX2NvbnRpbnVlP2FwcF9jaGVja291dD1ub1x1MDAyNm9yZGVyX2NoYW5uZWw9c3ByZWVcdTAwMjZvcmRlcl9udW1iZXI9UjIyNjIyNjU3NVx1MDAyNnRyYW5faWQ9UEYySU0yMVEiLCJpb3Nfc2NoZW1lIjoiYm9va21lcGx1czovL2NvbnRpZ28uYXNpYS93ZWJob29rL3BheXdheXMvdjJfY29udGludWU/YXBwX2NoZWNrb3V0PW5vXHUwMDI2b3JkZXJfY2hhbm5lbD1zcHJlZVx1MDAyNm9yZGVyX251bWJlcj1SMjI2MjI2NTc1XHUwMDI2dHJhbl9pZD1QRjJJTTIxUSJ9"
+      end
+    end
+  end
+  # described_class '#return_deeplink' do
+  #   subject { described_class.new(payment) }
+
+  #   context 'when return_deeplink_url is present?' do
+  #     let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
+  #     let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+  #     it 'encode deeplink for ios & android in base 64' do
+  #       allow(subject).to receive(:return_deeplink_url).and_return "bookmeplus://contigo.asia/webhook/payways/v2_continue"
+
+  #       expect(subject.return_deeplink).to eq ""
+  #     end
+  #   end
+  # end
   describe "#view_type" do
     it "return view_type: hosted_view for app checkout" do
       payment = create(:payway_payment)
@@ -119,6 +200,7 @@ RSpec.describe Vpago::PaywayV2::Base do
     let(:payment_option) { 'abapay' }
     let(:return_url) { 'https://contigo.asia/webhook/payways/return' }
     let(:continue_success_url) { 'https://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_number=R127975733&tran_id=PFSG7VBE' }
+    let(:return_deeplink) { 'eyJhbmRyb2lkX3NjaGVtZSI6ImJvb2ttZXBsdXM6Ly9jb250aWdvLmFzaWEvd2ViaG9vay9wYXl3YXlzL3YyX2NvbnRpbnVlP2FwcF9jaGVja291dD1ub1x1MDAyNm9yZGVyX2NoYW5uZWw9c3ByZWVcdTAwMjZvcmRlcl9udW1iZXI9UjIyNjIyNjU3NVx1MDAyNnRyYW5faWQ9UEYySU0yMVEiLCJpb3Nfc2NoZW1lIjoiYm9va21lcGx1czovL2NvbnRpZ28uYXNpYS93ZWJob29rL3BheXdheXMvdjJfY29udGludWU/YXBwX2NoZWNrb3V0PW5vXHUwMDI2b3JkZXJfY2hhbm5lbD1zcHJlZVx1MDAyNm9yZGVyX251bWJlcj1SMjI2MjI2NTc1XHUwMDI2dHJhbl9pZD1QRjJJTTIxUSJ9' }
     let(:return_params) { "{\"tran_id\":\"PFSG7VBE\"}" }
 
     before do
@@ -133,6 +215,7 @@ RSpec.describe Vpago::PaywayV2::Base do
       allow(subject).to receive(:payment_option).and_return(payment_option)
       allow(subject).to receive(:return_url).and_return(return_url)
       allow(subject).to receive(:continue_success_url).and_return(continue_success_url)
+      allow(subject).to receive(:return_deeplink).and_return(return_deeplink)
       allow(subject).to receive(:return_params).and_return(return_params)
     end
 
@@ -152,6 +235,7 @@ RSpec.describe Vpago::PaywayV2::Base do
           payment_option,
           return_url,
           continue_success_url,
+          return_deeplink,
           return_params
         ].join(""))
       end
@@ -175,6 +259,7 @@ RSpec.describe Vpago::PaywayV2::Base do
           payment_option,
           return_url,
           continue_success_url,
+          return_deeplink,
           return_params,
           payout
         ].join(""))

--- a/spec/lib/vpago/payway_v2/payouts_params_constructor_spec.rb
+++ b/spec/lib/vpago/payway_v2/payouts_params_constructor_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Vpago::PaywayV2::PayoutsParamsConstructor do
       expect(subject).to receive(:group_payouts).and_call_original
       expect(subject).to receive(:format_payouts).and_call_original
 
-      expect(subject.call).to eq([
+      expect(subject.call).to match_array([
         { acc: payout_profile1.bank_account_number, amt: '10.00' }, # combine of line_item_0 5$ + line_item_1 5$
         { acc: payout_profile2.bank_account_number, amt: '11.00' },
         { acc: default_payout_profile.bank_account_number, amt: '12.00' },


### PR DESCRIPTION
This will show new transition, instead of pop, it push to app directly.

https://github.com/user-attachments/assets/99192481-80d5-4671-8e65-96b4ed55f2ba

For web / telegram web bot, this field seem to be ignored by ABA.


