### PR TITLE
close #187 allow frontend to pass return_deeplink_url

### DIFF
--- a/app/controllers/spree/api/v2/storefront/checkout_controller_decorator.rb
+++ b/app/controllers/spree/api/v2/storefront/checkout_controller_decorator.rb
@@ -9,8 +9,8 @@ module Spree
 
           # :order_token, :payment_number
           def request_update_payment
-          # this action is mostly called after order is completed. 
-          # spree_current_order will be nil in this case, so we need to manual find.
+            # this action is mostly called after order is completed.
+            # spree_current_order will be nil in this case, so we need to manual find.
             order = find_order_by_token(params[:order_token])
 
             if order.paid?
@@ -32,10 +32,15 @@ module Spree
             raise ActiveRecord::RecordNotFound if payments.blank?
 
             last_payment = payments.last
-            payment_redirect = ::Vpago::PaymentRedirectHandler.new(payment: last_payment).process
+            payment_redirect = ::Vpago::PaymentRedirectHandler.new(
+              payment: last_payment,
+              override_return_deeplink_url: params[:override_return_deeplink_url]
+            ).process
 
             if payment_redirect.error_message.blank?
-              render_serialized_payload { payment_redirect_serializer.new(payment_redirect, params: serializer_params).serializable_hash }
+              render_serialized_payload do
+                payment_redirect_serializer.new(payment_redirect, params: serializer_params).serializable_hash
+              end
             else
               render_error_payload(payment_redirect.error_message)
             end
@@ -69,4 +74,4 @@ module Spree
   end
 end
 
-::Spree::Api::V2::Storefront::CheckoutController.prepend(::Spree::Api::V2::Storefront::CheckoutControllerDecorator)
+Spree::Api::V2::Storefront::CheckoutController.prepend(Spree::Api::V2::Storefront::CheckoutControllerDecorator)

--- a/app/services/vpago/payment_redirect_handler.rb
+++ b/app/services/vpago/payment_redirect_handler.rb
@@ -5,15 +5,22 @@ module Vpago
     include ActiveModel::Serialization
 
     attr_accessor :redirect_options, :error_message
-    attr_reader :payment, :payment_method_type, :gateway_params, :action_url, :vapgo_checkout_service
+    attr_reader :payment, :payment_method_type, :gateway_params, :action_url, :vapgo_checkout_service,
+                :override_return_deeplink_url
 
-    delegate      :id, :amount, :response_code, :number, :state,
-                  :payment_method_id, :payment_method_name,
-              to: :payment
+    delegate :id, :amount, :response_code, :number, :state,
+             :payment_method_id, :payment_method_name,
+             to: :payment
 
-    def initialize(payment:)
+    def initialize(payment:, override_return_deeplink_url: nil)
       @payment = payment
-      @vapgo_checkout_service = payment.payment_method.vapgo_checkout_service.presence&.new(payment)
+      @override_return_deeplink_url = override_return_deeplink_url
+
+      @vapgo_checkout_service = payment.payment_method.vapgo_checkout_service.presence&.new(
+        payment,
+        { override_return_deeplink_url: override_return_deeplink_url }
+      )
+
       @gateway_params = vapgo_checkout_service&.gateway_params
       @action_url = vapgo_checkout_service&.action_url
     end
@@ -96,7 +103,8 @@ module Vpago
 
     def send_process_payway_v2_payment
       options = {
-        app_checkout: true
+        app_checkout: true,
+        override_return_deeplink_url: override_return_deeplink_url,
       }
 
       abapay_payment = ::Vpago::PaywayV2::Checkout.new(@payment, options)

--- a/lib/vpago/payway_v2/base.rb
+++ b/lib/vpago/payway_v2/base.rb
@@ -120,11 +120,13 @@ module Vpago
 
       def return_deeplink_url
         scheme = @payment.payment_method.preferences[:deeplink_scheme]
-        return nil unless scheme.present?
+
+        # let client pass override return deeplink eg. from tg://t.me
+        return @options[:override_return_deeplink_url] if @options[:override_return_deeplink_url].present?
         return nil unless continue_success_url.present?
 
         uri = URI.parse(continue_success_url)
-        uri.scheme = scheme
+        uri.scheme = scheme if is_app_checkout? && scheme.present?
         uri.to_s
       end
 

--- a/spec/lib/vpago/payway_v2/base_spec.rb
+++ b/spec/lib/vpago/payway_v2/base_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe Vpago::PaywayV2::Base do
   describe "#return_deeplink_url" do
     subject { described_class.new(payment) }
 
+    context 'when override_return_deeplink_url is present' do      
+      let(:method) { create(:payway_v2_gateway) }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      subject { described_class.new(payment, { override_return_deeplink_url: 'tg://t.me' }) }
+
+      it 'return override_return_deeplink_url directly' do
+        expect(subject.return_deeplink_url).to eq 'tg://t.me'
+      end
+    end
+
     context 'when continue_callback_url is not present' do
       let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
       let(:payment) { create(:payway_v2_payment, payment_method: method) }
@@ -78,16 +89,37 @@ RSpec.describe Vpago::PaywayV2::Base do
       let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: nil) }
       let(:payment) { create(:payway_v2_payment, payment_method: method) }
 
-      it "return nil" do
+      it "return continue_callback_url" do
         ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
 
-        expect(subject.return_deeplink_url).to eq nil
+        allow(payment).to receive(:number).and_return "PF2IM21Q"
+        allow(payment.order).to receive(:number).and_return "R226226575"
+
+        expect(subject.return_deeplink_url).to eq 'https://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
       end
     end
 
-    context 'when continue_callback_url & preferred_deeplink_scheme is present' do
+    context 'when preferred_deeplink_scheme is present but is not app_checkout' do
+      let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: nil) }
+      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      subject { described_class.new(payment, { app_checkout: false }) }
+
+      it "return continue_callback_url" do
+        ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
+
+        allow(payment).to receive(:number).and_return "PF2IM21Q"
+        allow(payment.order).to receive(:number).and_return "R226226575"
+
+        expect(subject.return_deeplink_url).to eq 'https://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
+      end
+    end
+
+    context 'when continue_callback_url & preferred_deeplink_scheme is present & is app checkout' do
       let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
       let(:payment) { create(:payway_v2_payment, payment_method: method) }
+
+      subject { described_class.new(payment, { app_checkout: true }) }
 
       it "return return_deeplink url" do
         ENV['PAYWAY_CONTINUE_SUCCESS_CALLBACK_URL'] = "https://contigo.asia/webhook/payways/v2_continue"
@@ -95,19 +127,20 @@ RSpec.describe Vpago::PaywayV2::Base do
         allow(payment).to receive(:number).and_return "PF2IM21Q"
         allow(payment.order).to receive(:number).and_return "R226226575"
   
-        expect(subject.return_deeplink_url).to eq 'bookmeplus://contigo.asia/webhook/payways/v2_continue?app_checkout=no&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
+        expect(subject.return_deeplink_url).to eq 'bookmeplus://contigo.asia/webhook/payways/v2_continue?app_checkout=yes&order_channel=spree&order_number=R226226575&tran_id=PF2IM21Q'
       end
     end
   end
 
-  describe "#subject.return_deeplink" do
+  describe "#return_deeplink" do
     context 'when return_deeplink_url is not present?' do
-      let(:method) { create(:payway_v2_gateway) }
-      let(:payment) { create(:payway_v2_payment, payment_method: method) }
+      let(:payment) { create(:payway_v2_payment) }
 
       subject { described_class.new(payment) }
 
       it 'return nil' do
+        allow(subject).to receive(:return_deeplink_url).and_return nil
+
         expect(subject.return_deeplink_url).to eq nil
         expect(subject.return_deeplink).to eq nil
       end
@@ -126,20 +159,7 @@ RSpec.describe Vpago::PaywayV2::Base do
       end
     end
   end
-  # described_class '#return_deeplink' do
-  #   subject { described_class.new(payment) }
 
-  #   context 'when return_deeplink_url is present?' do
-  #     let(:method) { create(:payway_v2_gateway, preferred_deeplink_scheme: 'bookmeplus') }
-  #     let(:payment) { create(:payway_v2_payment, payment_method: method) }
-
-  #     it 'encode deeplink for ios & android in base 64' do
-  #       allow(subject).to receive(:return_deeplink_url).and_return "bookmeplus://contigo.asia/webhook/payways/v2_continue"
-
-  #       expect(subject.return_deeplink).to eq ""
-  #     end
-  #   end
-  # end
   describe "#view_type" do
     it "return view_type: hosted_view for app checkout" do
       payment = create(:payway_payment)


### PR DESCRIPTION
### `>>>>> base branch : develop <<<<<<<`

In this PR:
- Allow client to pass override return deeplink
- Only generate return deeplink with scheme on app checkout
- DEMO: https://github.com/bookmebus/cm-market-app/pull/1681