### PR TITLE
close #225 mark payment as complete for ticket seller

### DIFF
--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -7,6 +7,22 @@ module Vpago
       base.after_update :cancel_pre_auth, if: :state_changed_to_failed?
     end
 
+    # @override
+    # order trigger payment.process! when calling order.next.
+    def process!
+      return complete! if payment_method.auto_capture? && payment_receive_manually?
+
+      super
+    end
+
+    def payment_receive_manually?
+      check_payment_method? && order.ticket_seller_user?
+    end
+
+    def check_payment_method?
+      payment_method.is_a?(Spree::PaymentMethod::Check)
+    end
+
     def state_changed_to_complete?
       saved_change_to_state? && state == 'completed'
     end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Payment, type: :model do
-  let!(:default_payout_profile) { create(:payway_payout_profile, active: true, bank_account_number: '333', default: true, verified_at: DateTime.current)}
+  let!(:default_payout_profile) { create(:payway_payout_profile, active: true, bank_account_number: '333', default: true, verified_at: DateTime.current) }
 
   describe "associations" do
     it { should have_many(:payouts).class_name('Spree::Payout').inverse_of(:payment) }
@@ -34,6 +34,46 @@ RSpec.describe Spree::Payment, type: :model do
 
           subject.save!
         end
+      end
+    end
+  end
+
+  describe '#process!' do
+    context 'when auto capture true & payment receive manually' do
+      let(:payment_method) { create(:check_payment_method, auto_capture: true) }
+      subject { create(:check_payment, state: 'checkout', payment_method: payment_method) }
+      
+      it 'complete payment during process directly' do
+        allow(subject).to receive(:payment_receive_manually?).and_return(true)
+        expect(subject).to receive(:complete!).and_call_original
+
+        subject.process!
+  
+        expect(subject.state).to eq 'completed'
+      end
+    end
+
+    context 'when auto capture false but payment receive manually' do
+      let(:payment_method) { create(:check_payment_method, auto_capture: false) }
+      subject { create(:check_payment, state: 'checkout', payment_method: payment_method) }
+
+      it 'does not complete the payment & just call super' do
+        allow(subject).to receive(:payment_receive_manually?).and_return(true)
+        expect(subject).not_to receive(:complete!)
+
+        subject.process!
+      end
+    end
+
+    context 'when auto capture true but not payment receive manually' do
+      let(:payment_method) { create(:check_payment_method, auto_capture: true) }
+      subject { create(:check_payment, state: 'checkout', payment_method: payment_method) }
+
+      it 'does not complete the payment & just call super' do
+        allow(subject).to receive(:payment_receive_manually?).and_return(false)
+        expect(subject).not_to receive(:complete!)
+
+        subject.process!
       end
     end
   end


### PR DESCRIPTION
All ticket seller logics are inside spree_vpago, so we don't have to do it in spree_cm_commissioner.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/0d4fb5d3-0248-43ac-8a9c-ec75425f630a">
