### PR TITLE
Close #245 build and publish gem

### DIFF
--- a/.github/workflows/test_and_publish_gem.yml
+++ b/.github/workflows/test_and_publish_gem.yml
@@ -10,8 +10,9 @@ on:
   push:
     branches:
       - 112-ci-cd
+      - 245-build-and-publish-gem
 jobs:
-  test:
+  test_and_publish_gem:
     runs-on: ubuntu-latest
 
     services:
@@ -23,7 +24,7 @@ jobs:
           POSTGRES_PASSWORD: mypassword
           POSTGRES_DB: test_db
 
-        ports: ['5432:5432']
+        ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -39,7 +40,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.0'
+          ruby-version: "3.2.0"
 
           # bundle-cache might cause problem when upgrading ruby. Disable it when upgrading to solve the problem.
           # bundler-cache: true
@@ -68,3 +69,28 @@ jobs:
           DATABASE_URL: postgres://myuser:mypassword@localhost:5432/test_db
         run: |
           bundle exec rake
+
+      - name: Build gem
+        env:
+          DATABASE_URL: postgres://myuser:mypassword@localhost:5432/test_db
+
+        # if: startsWith(github.ref, 'refs/tags/') # Only on tag pushes
+        if: |
+          startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/245-build-and-publish-gem'
+        run: |
+          gem build *.gemspec
+
+      # Publish the gem
+      - name: Publish gem
+        env:
+          DATABASE_URL: postgres://myuser:mypassword@localhost:5432/test_db
+
+        # if: startsWith(github.ref, 'refs/tags/') # Only on tag pushes
+        # (github.event_name == 'push' && github.ref == 'refs/heads/2405-build-and-publish-gem')
+        if: |
+          startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/245-build-and-publish-gem'
+        run: |
+          mkdir -p ~/.gem
+          echo ":rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push *.gem

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gemfiles/*.gemfile.lock
 vendor/cache
 .byebug_history
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpreeVpago
 
-Introduction goes here.
+![Spree Vpago](https://github.com/bookmebus/spree_vpago/actions/workflows/test_and_publish_gem.yml/badge.svg?branch= "Build status")
 
 ## Installation
 
@@ -24,7 +24,29 @@ Introduction goes here.
 
 4. Restart your server
 
-If your server was running, restart it so that it can find the assets properly.
+   If your server was running, restart it so that it can find the assets properly.
+
+## Releasing
+
+To release the gem:
+
+1. Bump new version in the file: lib/spree_vpago/version.rb, for example
+
+   ```ruby
+   VERSION = '1.8.0-beta1'.freeze
+   ```
+
+   to release `1.8.0-beta1`
+
+2. Tag a repo with the same version, for example
+
+   ```sh
+   git tag 1.8.0-beta1
+   ```
+
+3. Push the tag to the repo and github action will build and push the gem to rubygem.org
+
+4. Get the gem version to the project in cm-market-server.
 
 ## Testing
 
@@ -44,7 +66,7 @@ require 'spree_vpago/factories'
 
 Run test
 
-```
+```sh
 rspec spec/
 ```
 
@@ -63,7 +85,7 @@ For desktop
     `
 Payment method configuration:
 
-```
+```env
 Icon Name: acleda
 ```
 
@@ -85,7 +107,7 @@ ENV['PAYWAY_V2_PRE_AUTH_CANCEL_PATH']
 
 Payment method configuration:
 
-```
+```env
 HOST: https://checkout-sandbox.payway.com.kh
 Payment Option: one of the [abapay, cards]
 Merchant: vtenh

--- a/db/migrate/20210430052432_add_fields_to_payment_sources.rb
+++ b/db/migrate/20210430052432_add_fields_to_payment_sources.rb
@@ -1,4 +1,4 @@
-class AddUserPaymentUpdaterIdAndUserPaymentUpdaterAtToSpreeVpagoPaymentSources < ActiveRecord::Migration[6.1]
+class AddFieldsToPaymentSources < ActiveRecord::Migration[6.1]
   def change
     add_column :spree_vpago_payment_sources, :updated_by_user_id, :integer
     add_column :spree_vpago_payment_sources, :updated_by_user_at, :datetime

--- a/lib/spree_vpago/version.rb
+++ b/lib/spree_vpago/version.rb
@@ -1,19 +1,9 @@
 module SpreeVpago
   module_function
 
-  # Returns the version of the currently loaded SpreeVpago as a
-  # <tt>Gem::Version</tt>.
+  VERSION = '0.1.0-beta'.freeze
+
   def version
-    Gem::Version.new VERSION::STRING
-  end
-
-  module VERSION
-    MAJOR = 0
-    MINOR = 1
-    TINY  = 11
-    # PRE   = 'alpha'.freeze
-
-    # STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
-    STRING = [MAJOR, MINOR, TINY].compact.join('.')
+    Gem::Version.new VERSION
   end
 end

--- a/spree_vpago.gemspec
+++ b/spree_vpago.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_vpago'
   s.version     = SpreeVpago.version
-  s.summary     = 'Add extension summary here'
-  s.description = 'Add (optional) extension description here'
+  s.summary     = 'Cambodian Payment Gateway Integration for Spree Commerce'
+  s.description = 'This Spree Commerce extension integrates Cambodian payment gateways, supporting ABA Bank, Acleda Bank, and Wing for secure and seamless transactions.'
   s.required_ruby_version = '>= 3.2.0'
 
   s.author    = 'You'


### PR DESCRIPTION
Using a Git-based gem (e.g., gem "my_gem", git: "https://...") instead of a versioned release from RubyGems introduces risks such as dependency instability, lack of reproducible builds, missing changelogs, and slower CI, while also increasing the risk of accidentally exposing credentials if a repository containing sensitive commits is shared.