### PR TITLE
Close #263 make email / phone optional for ABA

### DIFF
--- a/app/models/vpago/address_decorator.rb
+++ b/app/models/vpago/address_decorator.rb
@@ -1,0 +1,10 @@
+module Vpago
+  module AddressDecorator
+    # override
+    def require_phone?
+      false
+    end
+  end
+end
+
+Spree::Address.prepend(Vpago::AddressDecorator) unless Spree::Address.included_modules.include?(Vpago::AddressDecorator)

--- a/lib/vpago/payway_v2/base.rb
+++ b/lib/vpago/payway_v2/base.rb
@@ -46,6 +46,7 @@ module Vpago
         @payment.number
       end
 
+      # optional
       def email
         @payment.order.email.presence || ENV.fetch('DEFAULT_EMAIL_FOR_PAYMENT', nil)
       end
@@ -79,12 +80,9 @@ module Vpago
         Vpago::Payway::CARD_TYPES.index(card_option).nil? ? Vpago::Payway::CARD_TYPE_ABAPAY : card_option
       end
 
-      def phone_country_code
-        '+855'
-      end
-
+      # optional
       def phone
-        @payment.order.billing_address.phone
+        @payment.order.billing_address&.phone
       end
 
       def api_key
@@ -128,8 +126,10 @@ module Vpago
       end
 
       def hash_data
-        result = "#{req_time}#{merchant_id}#{transaction_id}#{amount}#{first_name}#{last_name}#{email}#{phone}"
+        result = "#{req_time}#{merchant_id}#{transaction_id}#{amount}#{first_name}#{last_name}"
 
+        result += email if email.present?
+        result += phone if phone.present?
         result += type if type.present?
         result += payment_option if payment_option.present?
         result += return_url if return_url.present?

--- a/lib/vpago/payway_v2/checkout.rb
+++ b/lib/vpago/payway_v2/checkout.rb
@@ -10,8 +10,6 @@ module Vpago
           type: type,
           firstname: first_name,
           lastname: last_name,
-          email: email,
-          phone: phone,
           payment_option: payment_option,
           return_url: return_url,
           continue_success_url: continue_success_url,
@@ -19,6 +17,8 @@ module Vpago
           hash: hash_hmac
         }
 
+        result[:email] = email unless email.nil?
+        result[:phone] = phone unless phone.nil?
         result[:return_deeplink] = return_deeplink unless return_deeplink.nil?
         result[:view_type] = view_type unless view_type.nil?
         result[:payout] = payout unless payout.nil?


### PR DESCRIPTION
Email & phone are optional by ABA, so we can allow our user not to input phone if organiser not needed.