### PR TITLE
Close #269 move capture payment to job instead run instantly

### DIFF
--- a/app/jobs/vpago/payment_capturer_job.rb
+++ b/app/jobs/vpago/payment_capturer_job.rb
@@ -1,0 +1,11 @@
+# Put :payment_processing at a higher priority in your project: config/sidekiq.yml
+module Vpago
+  class PaymentCapturerJob < ::ApplicationUniqueJob
+    queue_as :payment_processing
+
+    def perform(payment_id)
+      payment = Spree::Payment.find(payment_id)
+      payment.capture! if payment.pending?
+    end
+  end
+end

--- a/app/jobs/vpago/payment_processor_job.rb
+++ b/app/jobs/vpago/payment_processor_job.rb
@@ -1,5 +1,8 @@
+# Put :payment_processing at a higher priority in your project: config/sidekiq.yml
 module Vpago
   class PaymentProcessorJob < ::ApplicationUniqueJob
+    queue_as :payment_processing
+
     def perform(options)
       payment = Spree::Payment.find_by(number: options[:payment_number])
       Vpago::PaymentProcessor.new(payment: payment).call

--- a/app/services/vpago/payment_processor.rb
+++ b/app/services/vpago/payment_processor.rb
@@ -55,7 +55,7 @@ module Vpago
 
     def handle_order_process_completed
       log_process('handle_order_process_completed') do
-        @payment.capture! if @payment.pending?
+        Vpago::PaymentCapturerJob.perform_now(@payment.id) if @payment.pending?
         user_informer.order_is_completed(processing: false)
       end
     end

--- a/spec/jobs/vpago/payment_capturer_job_spec.rb
+++ b/spec/jobs/vpago/payment_capturer_job_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+RSpec.describe Vpago::PaymentCapturerJob, type: :job do
+  let(:order) { create(:order_with_line_items, state: :payment) }
+  let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order) }
+
+  it 'is enqueued on the payment_processing queue' do
+    expect {
+      described_class.perform_later(payment.id)
+    }.to have_enqueued_job(described_class)
+      .with(payment.id)
+      .on_queue('payment_processing')
+  end
+
+  context 'when payment is pending' do
+    before do
+      # Stub `pending?` to return true so `capture!` is called
+      allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(true)
+      expect(payment.state).to eq 'checkout'
+    end
+  
+    it 'calls capture! on the payment if it is pending' do
+      expect_any_instance_of(Spree::Payment).to receive(:capture!).and_call_original
+      described_class.new.perform(payment.id)
+  
+      expect(payment.reload.state).to eq 'completed'
+    end    
+  end
+
+  context 'when payment is not pending' do
+    before do
+      allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(false)
+      expect(payment.state).to eq 'checkout'
+    end
+
+    it 'does not call capture!' do
+      expect_any_instance_of(Spree::Payment).not_to receive(:capture!)
+      described_class.new.perform(payment.id)
+
+      expect(payment.reload.state).to eq 'checkout'
+    end
+  end
+end

--- a/spec/jobs/vpago/payment_processor_job_spec.rb
+++ b/spec/jobs/vpago/payment_processor_job_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe Vpago::PaymentProcessorJob, type: :job do
   let!(:payment) { create(:payway_v2_payment) }
   let!(:processor) { Vpago::PaymentProcessor.new(payment: payment) }
 
+  it 'is enqueued on the payment_processing queue' do
+    expect {
+      described_class.perform_later(payment_number: payment.number)
+    }.to have_enqueued_job(described_class)
+      .with(payment_number: payment.number)
+      .on_queue('payment_processing')
+  end
+
   describe '#perform' do
     it 'find payment & call process payment' do
       expect(Spree::Payment).to receive(:find_by).with(number: payment.number).and_return(payment)

--- a/spec/services/vpago/payment_processor_spec.rb
+++ b/spec/services/vpago/payment_processor_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Vpago::PaymentProcessor do
+  include ActiveJob::TestHelper
+
   let(:user_informer) { ::Vpago::UserInformers::Firebase.new(payment.order) }
 
   let(:order) { create(:order_with_line_items, state: :payment) }
@@ -156,17 +158,21 @@ RSpec.describe Vpago::PaymentProcessor do
   describe '#handle_order_process_completed' do
     context 'when pre-auth enabled or payment is authorized' do
       before do
-        allow(payment).to receive(:pending?).and_return(true)
+        allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(true)
       end
 
-      it 'capture the payment & inform user the order is completed!' do
+      it 'capture the payment in job & inform user the order is completed!' do
         expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} with args: \[]")).once
         expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} in")).once
 
-        expect(payment).to receive(:capture!)
+        expect(Vpago::PaymentCapturerJob).to receive(:perform_now).with(payment.id).and_call_original
         expect(user_informer).to receive(:order_is_completed).with(processing: false)
-
-        subject.send(:handle_order_process_completed)
+        
+        perform_enqueued_jobs do
+          expect(payment.state).to eq 'checkout'
+          subject.send(:handle_order_process_completed)
+          expect(payment.reload.state).to eq 'completed'
+        end
       end
     end
 


### PR DESCRIPTION
## Problem
- User make purchase & pay & in processing payment screen
- Our system, we:
  step 1. Check payment & mark payment as hold
  step 2. Process order & mark order complete
  step 3. Capture the payment
    In step 3, capture payment can have connection issue which cause the whole class to failed & refund to user. But when refund, order state still complete which cause problem.

## Solution
Once pass the step 2, which mean payment is hold & order is completed, we capture payment in job instead. So, If paymen.capture fail in the case such as a connection error to ABA, it will retry in sidekiq.

& User will get the ticket in that case (instead refund & keep order state still complete).
