### PR TITLE
Close #288 pass payout params to complete pre-auth API

### DIFF
--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -59,7 +59,6 @@ module Vpago
     def vattanac_mini_app_payment?
       payment_method.type_vattanac_mini_app?
     end
-    
   end
 end
 

--- a/lib/vpago/payway_v2/pre_auth_completer.rb
+++ b/lib/vpago/payway_v2/pre_auth_completer.rb
@@ -40,11 +40,14 @@ module Vpago
       end
 
       def merchant_auth
-        {
+        merchant_auth = {
           'mc_id' => merchant_id,
           'tran_id' => transaction_id,
           'complete_amount' => amount.to_s
-        }.to_json
+        }
+
+        merchant_auth['payout'] = payout unless payout.nil?
+        merchant_auth.to_json
       end
 
       def merchant_auth_encryption

--- a/spec/cassettes/payway_v2_pre_auth_completer_with_payout.yml
+++ b/spec/cassettes/payway_v2_pre_auth_completer_with_payout.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://checkout-sandbox.payway.com.kh/api/merchant-portal/merchant-access/online-transaction/pre-auth-completion
+    body:
+      encoding: UTF-8
+      string: hash=Sk4I%2FtfDXIkEQXT%2FXXJESYf8oCZCn9Iaq94g3kpKLiLUmegJPCuYavMOloXMRUZWgdrjkTXWQouRAe93No2pcA%3D%3D&merchant_auth=aeJtM4LQLhN%2Bri%2B5VcMbPwLI98RItpaXg5jhooEgXVS8RiB%2Bhq6TP4yPqNmVNZ8nb11Da02MLe5Jjirat6vPGVA7T4GySlhX1MFL%2BgbG5ng3qQQYGscZEzjwla6BqwaLe9ZT9bIuNW7AZa3%2B%2FPd3bFOGsBHRItFe7LJ2%2BGGxz2ESr%2BescB65%2BmZfYWs6tZmZhWZFSZsPY4odMZHtZ8Al0uuzeT9vCLb%2FXxVuTHspCrD5vHWsvqLonTwdWFqI4%2F2I%2BWztOevJsCP%2FomjuuTKqSavB4%2BPjs3q6JiqE9f5pqW2xT%2B7CjXKTn6YuiJUq0uk89z3YvF9AbGrDl%2FZjnsrozA%3D%3D&merchant_id=contigoasia&request_time=20250805041644
+    headers:
+      User-Agent:
+      - Faraday v2.7.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Tue, 05 Aug 2025 04:16:44 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      cache-control:
+      - private, must-revalidate
+      pragma:
+      - no-cache
+      expires:
+      - "-1"
+      x-ratelimit-limit:
+      - '100000'
+      x-ratelimit-remaining:
+      - '93480'
+      access-control-allow-origin:
+      - "*"
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-security-policy:
+      - upgrade-insecure-requests
+      referrer-policy:
+      - same-origin
+      permissions-policy:
+      - geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()
+      cf-cache-status:
+      - DYNAMIC
+      set-cookie:
+      - __cf_bm=yC1JwkZiRL9Yo3orCMS4_e0nUSqyGLy8rxSckhl4z78-1754367404-1.0.1.1-q4Aj0b4Ovn_4INsGoMyneVrizwPBvWALpj76imtR8wF4WUnd9fgfOb8drI8sa62SSo5XAYUiiz_6HDpTZY.GvyxX5IoyuXtFPU5239v1mC0;
+        path=/; expires=Tue, 05-Aug-25 04:46:44 GMT; domain=.payway.com.kh; HttpOnly;
+        Secure; SameSite=None
+      server:
+      - cloudflare
+      cf-ray:
+      - 96a37b174e1c6e51-HKG
+      content-encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: '{"grand_total":"30.00","currency":"USD","transaction_status":"COMPLETED","status":{"code":"00","message":"Success!","tran_id":"PW7Q6M5U"}}'
+  recorded_at: Tue, 05 Aug 2025 04:16:44 GMT
+recorded_with: VCR 6.2.0

--- a/spec/lib/vpago/payway_v2/pre_auth_completer_spec.rb
+++ b/spec/lib/vpago/payway_v2/pre_auth_completer_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe Vpago::PaywayV2::PreAuthCompleter do
       response = subject.json_response
 
       expect(subject.success?).to eq true 
+      expect(subject.merchant_auth).not_to include('"payout"')
       expect(response['transaction_status']).to eq 'COMPLETED' 
-      expect(response['status']['message']).to eq 'Success!' 
+      expect(response['status']['message']).to eq 'Success!'
     end
 
     it 'failed when transaction_id is invalid' do 
@@ -50,6 +51,29 @@ RSpec.describe Vpago::PaywayV2::PreAuthCompleter do
 
       expect(subject.success?).to eq false 
       expect(response['status']['message']).to eq 'Unable to complete or cancel Pre Auth' 
+    end
+
+    context 'when payout is enabled' do
+      before do
+        allow_any_instance_of(Vpago::PaywayV2::PayoutsParamsConstructor).to receive(:call).and_return([
+          {:acc=>"002092768", :amt=>"27.00"},
+          {:acc=>"111111111", :amt=>"3.00"}
+        ])
+      end
+
+      it 'successfully collect the amount with payout' do 
+        expect(subject).to receive(:pre_auth_response).and_call_original
+
+        VCR.use_cassette('payway_v2_pre_auth_completer_with_payout') do
+          subject.call
+        end
+
+        response = subject.json_response
+
+        expect(subject.merchant_auth).to include('"payout"') # contains payout params
+        expect(response['transaction_status']).to eq 'COMPLETED' 
+        expect(response['status']['message']).to eq 'Success!' 
+      end
     end
   end
 end


### PR DESCRIPTION
## What in this PR?
Add payout to pre-auth completion API. Because when payout & pre-auth are both enabled, without passing payout to pre-auth api, payout won't work.

## Testing
In spec, I use real sandbox transaction + record with vcr. Following are real test on staging:

| |
| - |
| <img width="1416" height="376" alt="image" src="https://github.com/user-attachments/assets/99312a6f-6059-43fd-89ca-0a24c567a112" /> |
| <img width="1415" height="719" alt="image" src="https://github.com/user-attachments/assets/cf07d707-445f-44d2-8f6f-c6cceab55697" /> |

## API Reference
https://developer.payway.com.kh/complete-pre-auh-transaction-with-payout-14666701e0

