### PR TITLE
Close #293 allow to create payment with cheque payment method

### DIFF
--- a/app/services/vpago/payments/find_or_create.rb
+++ b/app/services/vpago/payments/find_or_create.rb
@@ -39,8 +39,9 @@ module Vpago
           }.compact
 
           payment.source = payment_method.payment_source_class.new(source_attributes)
-          payment.save!
         end
+
+        payment.save!
 
         return failure(payment) if payment.errors.any?
 


### PR DESCRIPTION
## Problem 

For the cheque payment method type, a source is not required. In the service, it is only initialized based on conditions but never save.