### PR TITLE
Close #312 improve payment log entry for better debugging

### DIFF
--- a/app/models/spree/gateway/payway_v2.rb
+++ b/app/models/spree/gateway/payway_v2.rb
@@ -58,10 +58,12 @@ module Spree
       checker = check_transaction(payment)
       payment.update(transaction_response: checker.json_response)
 
+      params = { check: { response: checker.json_response } }
+
       if checker.success?
-        ActiveMerchant::Billing::Response.new(true, 'Payway Gateway: Authorized')
+        ActiveMerchant::Billing::Response.new(true, 'Payway Gateway: Authorized', params)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Payway Gateway: Authorization Failed')
+        ActiveMerchant::Billing::Response.new(false, 'Payway Gateway: Authorization Failed', params)
       end
     end
 
@@ -140,14 +142,16 @@ module Spree
       canceler = Vpago::PaywayV2::PreAuthCanceler.new(payment)
       canceler.call
 
-      [canceler.success?, canceler.request_data]
+      data = { request: canceler.request_data, response: canceler.json_response }
+      [canceler.success?, data]
     end
 
     def complete_pre_auth(payment)
       completer = Vpago::PaywayV2::PreAuthCompleter.new(payment)
-
       completer.call
-      [completer.success?, completer.request_data]
+
+      data = { request: completer.request_data, response: completer.json_response }
+      [completer.success?, data]
     end
 
     def confirm_payouts(payment)

--- a/app/models/spree/gateway/true_money.rb
+++ b/app/models/spree/gateway/true_money.rb
@@ -40,17 +40,18 @@ module Spree
       params[:payment_response] = payment.transaction_response
 
       if success
-        ActiveMerchant::Billing::Response.new(true, 'Payway Gateway: Purchased', params)
+        ActiveMerchant::Billing::Response.new(true, 'True money Gateway: Purchased', params)
       else
-        ActiveMerchant::Billing::Response.new(false, 'Payway Gateway: Purchasing Failed', params)
+        ActiveMerchant::Billing::Response.new(false, 'True money Gateway: Purchasing Failed', params)
       end
     end
 
     # override
-    def void(_response_code, gateway_options)
-      _, payment_number = gateway_options[:order_id].split('-')
-      payment = Spree::Payment.find_by(number: payment_number)
+    def void(_response_code, _gateway_options)
+      ActiveMerchant::Billing::Response.new(true, 'True money Gateway: Payment has been voided.')
+    end
 
+    def cancel(_response_code, payment)
       if payment.true_money_payment?
         params = {}
         success, params[:refund_response] = true_money_refund(payment)
@@ -70,14 +71,6 @@ module Spree
       refund_issuer.call
 
       [refund_issuer.success?, refund_issuer.parsed_response]
-    end
-
-    def cancel(_response_code, _payment)
-      # we can use this to send request to payment gateway api to cancel the payment ( void )
-      # currently True money does not support to cancel the gateway
-
-      # in our case don't do anything
-      ActiveMerchant::Billing::Response.new(true, '')
     end
 
     private

--- a/app/models/spree/gateway/vattanac_mini_app.rb
+++ b/app/models/spree/gateway/vattanac_mini_app.rb
@@ -34,10 +34,12 @@ module Spree
     end
 
     # override
-    def void(_response_code, gateway_options)
-      _, payment_number = gateway_options[:order_id].split('-')
-      payment = Spree::Payment.find_by(number: payment_number)
+    def void(_response_code, _gateway_options)
+      ActiveMerchant::Billing::Response.new(true, 'Vattanac order has been voided.')
+    end
 
+    # override
+    def cancel(_response_code, payment)
       if payment.vattanac_mini_app_payment?
         params = {}
         success, params[:refund_response] = vattanac_mini_app_refund(payment)
@@ -57,14 +59,6 @@ module Spree
       refund_issuer.call
 
       [refund_issuer.success?, refund_issuer.response]
-    end
-
-    def cancel(_response_code, _payment)
-      # we can use this to send request to payment gateway api to cancel the payment ( void )
-      # currently Payway does not support to cancel the gateway
-
-      # in our case don't do anything
-      ActiveMerchant::Billing::Response.new(true, 'Vattanac order has been cancelled.')
     end
   end
 end

--- a/app/models/vpago/log_entry_decorator.rb
+++ b/app/models/vpago/log_entry_decorator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Vpago
+  module LogEntryDecorator
+    def parsed_details
+      @parsed_details ||= if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1.0')
+                            YAML.safe_load(details, permitted_classes: permitted_classes_for_yaml, aliases: true)
+                          else
+                            YAML.safe_load(details, permitted_classes_for_yaml)
+                          end
+    end
+
+    private
+
+    def permitted_classes_for_yaml
+      [
+        ActiveMerchant::Billing::Response,
+        Symbol,
+        Hash
+      ]
+    end
+  end
+end
+
+Spree::LogEntry.prepend(Vpago::LogEntryDecorator) if Spree::LogEntry.included_modules.exclude?(Vpago::LogEntryDecorator)

--- a/app/overrides/spree/admin/log_entries/index/table.html.erb.deface
+++ b/app/overrides/spree/admin/log_entries/index/table.html.erb.deface
@@ -1,0 +1,66 @@
+<!-- replace "#listing_log_entries" -->
+
+<div class="bg-white border rounded table-responsive">
+  <table class="table" id='listing_log_entries'>
+    <% @log_entries.each do |entry| %>
+      <thead class="text-muted">
+        <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
+          <td colspan="2">
+            <h4>
+              <i class="icon icon-<%= entry.parsed_details.success? ? 'save' : 'cancel' %>"></i>
+              <%= pretty_time(entry.created_at) %>
+            </h4>
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Message</td>
+          <td><%= entry.parsed_details.message %></td>
+        </tr>
+        
+        <% if entry.parsed_details.params.present? %>
+          <tr>
+            <td>Details</td>
+            <td>
+              <button type="button" 
+                      class="btn btn-sm btn-outline-secondary" 
+                      data-toggle="modal" 
+                      data-target="#detailsModal-<%= entry.id %>">
+                View Details
+              </button>
+
+              <!-- Modal -->
+              <div class="modal fade" id="detailsModal-<%= entry.id %>" tabindex="-1" role="dialog" aria-labelledby="detailsModalLabel-<%= entry.id %>" aria-hidden="true">
+                <div class="modal-dialog modal-lg" role="document">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <h5 class="modal-title" id="detailsModalLabel-<%= entry.id %>">
+                        Payment Details - <%= pretty_time(entry.created_at) %>
+                      </h5>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                      </button>
+                    </div>
+                    <div class="modal-body" style="max-height: 500px; overflow-y: auto;">
+                      <% entry.parsed_details.params.each do |key, value| %>
+                        <div class="mb-4">
+                          <h6 class="text-muted"><%= key.to_s.titleize %></h6>
+                          <pre class="p-3 border rounded bg-light" style="max-height: 300px; overflow-y: auto;"><%= JSON.pretty_generate(value) rescue value.inspect %></pre>
+                        </div>
+                      <% end %>
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    <% end %>
+  </table>
+</div>
+

--- a/spec/models/spree/gateway/payway_v2_spec.rb
+++ b/spec/models/spree/gateway/payway_v2_spec.rb
@@ -301,13 +301,48 @@ RSpec.describe Spree::Gateway::PaywayV2, type: :model do
   describe '#cancel_pre_auth' do
     let(:canceler) { Vpago::PaywayV2::PreAuthCanceler.new(payment) }
 
-    it 'execute .call and returns success & request_data' do
+    it 'execute .call and returns success with both request & response data' do
       expect(Vpago::PaywayV2::PreAuthCanceler).to receive(:new).with(payment).and_return(canceler)
       expect(canceler).to receive(:call)
       expect(canceler).to receive(:success?).and_return(true)
-      expect(canceler).to receive(:request_data).and_return({'merchant_id': 'any-merchant-id'})
+      expect(canceler).to receive(:request_data).and_return({ 'merchant_id' => 'any-merchant-id' })
+      expect(canceler).to receive(:json_response).and_return({ 'status' => { 'code' => '00' } })
 
-      expect(payment_method.send(:cancel_pre_auth, payment)).to eq([true, {'merchant_id': 'any-merchant-id'}])
+      success, data = payment_method.send(:cancel_pre_auth, payment)
+      expect(success).to be true
+      expect(data[:request]).to eq({ 'merchant_id' => 'any-merchant-id' })
+      expect(data[:response]).to eq({ 'status' => { 'code' => '00' } })
+    end
+
+    context 'with VCR integration' do
+      before do
+        allow_any_instance_of(Vpago::PaywayV2::PreAuthCanceler).to receive(:cancel_url).and_return('https://checkout-sandbox.payway.com.kh/api/merchant-portal/merchant-access/online-transaction/pre-auth-cancellation')
+        allow_any_instance_of(Vpago::PaywayV2::PreAuthCanceler).to receive(:merchant_auth_encryption).and_return('mocked_encrypted_value')
+      end
+
+      it 'returns both request and response data on success' do
+        VCR.use_cassette('payway_v2_pre_auth_canceler_status_0') do
+          success, data = payment_method.send(:cancel_pre_auth, payment)
+
+          expect(success).to be true
+          expect(data[:request]).to be_a(Hash)
+          expect(data[:request]).to have_key(:merchant_id)
+          expect(data[:response]).to be_a(Hash)
+          expect(data[:response]['status']['code']).to eq('00')
+          expect(data[:response]['transaction_status']).to eq('CANCELLED')
+        end
+      end
+
+      it 'returns both request and response data on failure' do
+        VCR.use_cassette('payway_v2_pre_auth_canceler_invalid_transaction') do
+          success, data = payment_method.send(:cancel_pre_auth, payment)
+
+          expect(success).to be false
+          expect(data[:request]).to be_a(Hash)
+          expect(data[:response]).to be_a(Hash)
+          expect(data[:response]['status']['message']).to eq('Invalid Transaction')
+        end
+      end
     end
   end
 
@@ -315,13 +350,48 @@ RSpec.describe Spree::Gateway::PaywayV2, type: :model do
   describe '#complete_pre_auth' do
     let(:completer) { Vpago::PaywayV2::PreAuthCompleter.new(payment) }
 
-    it 'execute .call and returns success & request_data' do
+    it 'execute .call and returns success with both request & response data' do
       expect(Vpago::PaywayV2::PreAuthCompleter).to receive(:new).with(payment).and_return(completer)
       expect(completer).to receive(:call)
       expect(completer).to receive(:success?).and_return(true)
-      expect(completer).to receive(:request_data).and_return({'merchant_id': 'any-merchant-id'})
+      expect(completer).to receive(:request_data).and_return({ 'merchant_id' => 'any-merchant-id' })
+      expect(completer).to receive(:json_response).and_return({ 'status' => { 'code' => '00' }, 'transaction_status' => 'COMPLETED' })
 
-      expect(payment_method.send(:cancel_pre_auth, payment)).to eq([true, {'merchant_id': 'any-merchant-id'}])
+      success, data = payment_method.send(:complete_pre_auth, payment)
+      expect(success).to be true
+      expect(data[:request]).to eq({ 'merchant_id' => 'any-merchant-id' })
+      expect(data[:response]).to eq({ 'status' => { 'code' => '00' }, 'transaction_status' => 'COMPLETED' })
+    end
+
+    context 'with VCR integration' do
+      before do
+        allow_any_instance_of(Vpago::PaywayV2::PreAuthCompleter).to receive(:complete_url).and_return('https://checkout-sandbox.payway.com.kh/api/merchant-portal/merchant-access/online-transaction/pre-auth-completion')
+        allow_any_instance_of(Vpago::PaywayV2::PreAuthCompleter).to receive(:merchant_auth_encryption).and_return('mocked_encrypted_value')
+      end
+
+      it 'returns both request and response data on success' do
+        VCR.use_cassette('payway_v2_pre_auth_completer_status_0') do
+          success, data = payment_method.send(:complete_pre_auth, payment)
+
+          expect(success).to be true
+          expect(data[:request]).to be_a(Hash)
+          expect(data[:request]).to have_key(:merchant_id)
+          expect(data[:response]).to be_a(Hash)
+          expect(data[:response]['status']['code']).to eq('00')
+          expect(data[:response]['transaction_status']).to eq('COMPLETED')
+        end
+      end
+
+      it 'returns both request and response data on failure' do
+        VCR.use_cassette('payway_v2_pre_auth_completer_invalid_transaction') do
+          success, data = payment_method.send(:complete_pre_auth, payment)
+
+          expect(success).to be false
+          expect(data[:request]).to be_a(Hash)
+          expect(data[:response]).to be_a(Hash)
+          expect(data[:response]['status']['message']).to eq('Invalid Transaction')
+        end
+      end
     end
   end
 

--- a/spec/models/vpago/log_entry_decorator_spec.rb
+++ b/spec/models/vpago/log_entry_decorator_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Vpago::LogEntryDecorator do
+  describe '#parsed_details' do
+    let(:response) do
+      ActiveMerchant::Billing::Response.new(
+        true,
+        'Transaction successful',
+        { transaction_id: '12345' },
+        authorization: 'AUTH123'
+      )
+    end
+
+    let(:details_hash) do
+      {
+        response: response,
+        status: :success,
+        metadata: { key: 'value' }
+      }
+    end
+
+    let(:yaml_details) { YAML.dump(details_hash) }
+    let(:log_entry) { Spree::LogEntry.new(details: yaml_details) }
+
+    it 'parses YAML details with permitted classes' do
+      parsed = log_entry.parsed_details
+
+      expect(parsed).to be_a(Hash)
+      expect(parsed[:response]).to be_a(ActiveMerchant::Billing::Response)
+      expect(parsed[:response].message).to eq('Transaction successful')
+      expect(parsed[:status]).to eq(:success)
+      expect(parsed[:metadata]).to eq({ key: 'value' })
+    end
+
+    it 'handles ActiveMerchant::Billing::Response objects' do
+      parsed = log_entry.parsed_details
+
+      expect(parsed[:response].success?).to be true
+      expect(parsed[:response].authorization).to eq('AUTH123')
+      expect(parsed[:response].params).to eq({ 'transaction_id' => '12345' })
+    end
+
+    it 'handles Symbol objects' do
+      parsed = log_entry.parsed_details
+
+      expect(parsed[:status]).to be_a(Symbol)
+      expect(parsed[:status]).to eq(:success)
+    end
+
+    it 'handles Hash objects' do
+      parsed = log_entry.parsed_details
+
+      expect(parsed[:metadata]).to be_a(Hash)
+      expect(parsed[:metadata][:key]).to eq('value')
+    end
+
+    it 'memoizes the parsed result' do
+      first_call = log_entry.parsed_details
+      second_call = log_entry.parsed_details
+
+      expect(first_call.object_id).to eq(second_call.object_id)
+    end
+
+    context 'with different Ruby versions' do
+      it 'uses appropriate YAML.safe_load parameters' do
+        expect(log_entry.parsed_details).to be_a(Hash)
+      end
+    end
+
+    context 'when details contain only basic types' do
+      let(:simple_details) { YAML.dump({ message: 'Test', count: 42 }) }
+      let(:log_entry) { Spree::LogEntry.new(details: simple_details) }
+
+      it 'parses simple YAML structures' do
+        parsed = log_entry.parsed_details
+
+        expect(parsed[:message]).to eq('Test')
+        expect(parsed[:count]).to eq(42)
+      end
+    end
+  end
+
+  describe 'module inclusion' do
+    it 'is prepended to Spree::LogEntry' do
+      expect(Spree::LogEntry.ancestors).to include(Vpago::LogEntryDecorator)
+    end
+
+    it 'responds to parsed_details method' do
+      log_entry = Spree::LogEntry.new
+
+      expect(log_entry).to respond_to(:parsed_details)
+    end
+  end
+end


### PR DESCRIPTION
## In this PR
- [x] Add bank response (from check status, request capture/cancel pre-auth.. APIs) to `Billing::Response` which will be saved to log_entries
- [x] Fix log entry not load in admin

----

With this PR, we can debug as follows:

| |
| - |
| <img width="1557" height="673" alt="image" src="https://github.com/user-attachments/assets/66f91f74-4c6c-4dfb-aca6-2923da674638" /> |
| <img width="1557" height="673" alt="image" src="https://github.com/user-attachments/assets/0079a512-e1d2-422f-89c4-3ca6a043bab2" /> |

