### PR TITLE
Close #314 allow failed payment to re-process/capture

### DIFF
--- a/app/assets/javascripts/vpago/vpago_payments/payment_processing_listener.js
+++ b/app/assets/javascripts/vpago/vpago_payments/payment_processing_listener.js
@@ -6,7 +6,9 @@ window.initPaymentProcessingListener = async function (
   function log(status, processing, reasonCode, reasonMessage) {
     console.log(`Status: ${status}`);
     console.log(`Reason Code: ${reasonCode}`);
-    console.log(`Processing: ${processing ? "Processing..." : "No more process."}`);
+    console.log(
+      `Processing: ${processing ? "Processing..." : "No more process."}`
+    );
     console.log(`Reason Message: ${reasonMessage}`);
   }
 
@@ -14,33 +16,80 @@ window.initPaymentProcessingListener = async function (
     firebaseConfigs,
     documentReferencePath,
 
-    onPaymentIsProcessing(orderState, paymentState, processing, reasonCode, reasonMessage) {
+    onPaymentIsProcessing(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
       log("Payment is processing", processing, reasonCode, reasonMessage);
     },
 
-    onOrderIsProcessing(orderState, paymentState, processing, reasonCode, reasonMessage) {
+    onPaymentIsRetrying(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
+      log("Payment is retrying", processing, reasonCode, reasonMessage);
+    },
+
+    onOrderIsProcessing(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
       log("Order is processing", processing, reasonCode, reasonMessage);
     },
 
-    onOrderIsCompleted(orderState, paymentState, processing, reasonCode, reasonMessage) {
+    onOrderIsCompleted(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
       log("Order is completed", processing, reasonCode, reasonMessage);
     },
 
-    onOrderProcessFailed(orderState, paymentState, processing, reasonCode, reasonMessage) {
+    onOrderProcessFailed(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
       log("Order process failed", processing, reasonCode, reasonMessage);
     },
 
-    onPaymentIsRefunded(orderState, paymentState, processing, reasonCode, reasonMessage) {
-      log("Payment is refunded", processing, reasonCode, reasonMessage);
-    },
-
-    onPaymentProcessFailed(orderState, paymentState, processing, reasonCode, reasonMessage) {
+    onPaymentProcessFailed(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
       log("Payment process failed", processing, reasonCode, reasonMessage);
     },
 
-    onCompleted(orderState, paymentState, processing, reasonCode, reasonMessage) {
-      log("Completed — redirecting to success URL", processing, reasonCode, reasonMessage);
+    onCompleted(
+      orderState,
+      paymentState,
+      processing,
+      reasonCode,
+      reasonMessage
+    ) {
+      log(
+        "Completed — redirecting to success URL",
+        processing,
+        reasonCode,
+        reasonMessage
+      );
       window.location.href = successUrl;
-    }
+    },
   });
 };

--- a/app/javascripts/vpago/vpago_payments/user_informers/firebase.js
+++ b/app/javascripts/vpago/vpago_payments/user_informers/firebase.js
@@ -6,10 +6,10 @@ async function listenToProcessingState({
   firebaseConfigs,
   documentReferencePath,
   onPaymentIsProcessing,
+  onPaymentIsRetrying,
   onOrderIsProcessing,
   onOrderIsCompleted,
   onOrderProcessFailed,
-  onPaymentIsRefunded,
   onPaymentProcessFailed,
   onCompleted,
 }) {
@@ -62,6 +62,20 @@ async function listenToProcessingState({
           },
         });
         break;
+      case "payment_is_retrying":
+        queueProcessor.queueStateChange({
+          minDelayInMs: 1500,
+          callback: async () => {
+            await onPaymentIsRetrying(
+              orderState,
+              paymentState,
+              processing,
+              reasonCode,
+              reasonMessage
+            );
+          },
+        });
+        break;
       case "order_is_processing":
         queueProcessor.queueStateChange({
           minDelayInMs: 1500,
@@ -95,20 +109,6 @@ async function listenToProcessingState({
           minDelayInMs: 1500,
           callback: async () => {
             await onOrderProcessFailed(
-              orderState,
-              paymentState,
-              processing,
-              reasonCode,
-              reasonMessage
-            );
-          },
-        });
-        break;
-      case "payment_is_refunded":
-        queueProcessor.queueStateChange({
-          minDelayInMs: 1500,
-          callback: async () => {
-            await onPaymentIsRefunded(
               orderState,
               paymentState,
               processing,

--- a/app/jobs/vpago/payment_canceler_job.rb
+++ b/app/jobs/vpago/payment_canceler_job.rb
@@ -1,11 +1,11 @@
 # Put :payment_processing at a higher priority in your project: config/sidekiq.yml
 module Vpago
-  class PaymentCapturerJob < ::ApplicationUniqueJob
+  class PaymentCancelerJob < ::ApplicationUniqueJob
     queue_as :payment_processing
 
     def perform(payment_id)
       payment = Spree::Payment.find(payment_id)
-      payment.capture! if payment.actions.include?('capture')
+      payment.cancel! if payment.actions.include?('cancel')
     end
   end
 end

--- a/app/jobs/vpago/payment_processor_job.rb
+++ b/app/jobs/vpago/payment_processor_job.rb
@@ -4,7 +4,7 @@ module Vpago
     queue_as :payment_processing
 
     def perform(options)
-      payment = Spree::Payment.find_by(number: options[:payment_number])
+      payment = Spree::Payment.find_by!(number: options[:payment_number])
       Vpago::PaymentProcessor.new(payment: payment).call
     end
   end

--- a/app/jobs/vpago/payment_voider_job.rb
+++ b/app/jobs/vpago/payment_voider_job.rb
@@ -1,11 +1,11 @@
 # Put :payment_processing at a higher priority in your project: config/sidekiq.yml
 module Vpago
-  class PaymentCapturerJob < ::ApplicationUniqueJob
+  class PaymentVoiderJob < ::ApplicationUniqueJob
     queue_as :payment_processing
 
     def perform(payment_id)
       payment = Spree::Payment.find(payment_id)
-      payment.capture! if payment.actions.include?('capture')
+      payment.void_transaction! if payment.actions.include?('void')
     end
   end
 end

--- a/app/models/spree/vpago_payment_source.rb
+++ b/app/models/spree/vpago_payment_source.rb
@@ -1,4 +1,5 @@
 class Spree::VpagoPaymentSource < Spree::Base
+  # deprecated preferences from older versions kept for data integrity
   preference :wing_response, :hash
   preference :acleda_response, :hash
   preference :payway_v2_response, :hash
@@ -11,11 +12,64 @@ class Spree::VpagoPaymentSource < Spree::Base
 
   # validates :updated_reason, presence: true, on: :update
 
+  # Define possible available actions for vpago payments.
+  # Then Spree::Payment#actions will select only those where can_<action>? returns true.
+  #
+  # These actions are triggered via: payment.send("#{action}!")
+  # - [void] can be triggered void_transaction (the alias by spree is to avoid conflict with the transition method name)
+  # - [open_checkout] is a view action and is handled manually in gems/spree_vpago/app/overrides/spree/admin/payments/_list/actions.html.erb.deface
+  # - [process] [capture] [void] [cancel] are built-in methods in the Spree::Payment model.
+  #
+  # Usages:
+  # See fire request method in gems/spree_backend/app/controllers/spree/admin/payments_controller.rb
+  # See jobs in gems/spree_vpago/app/jobs/vpago which are triggered by processor jobs.
+  #
+  # override
   def actions
-    actions = []
-    actions << 'open_checkout' if payment.checkout?
-    actions << 'process' if payment.processing? || payment.checkout? || payment.send(:has_invalid_state?)
-    actions << 'capture' if payment.pending?
-    actions
+    %w[open_checkout process capture void cancel]
+  end
+
+  def can_open_checkout?(payment)
+    payment.checkout?
+  end
+
+  def can_process?(payment)
+    return false if payment.completed? || payment.pending?
+
+    payment.processing? || payment.checkout? || payment.send(:has_invalid_state?)
+  end
+
+  # The flow is as follows: payment authorized -> order completed -> capture the amount -> end.
+  def can_capture?(payment)
+    # Capture action should be triggered when the order is completed/secured for the user.
+    # Otherwise, we don't need to capture the payment as the order is not completed.
+    return false unless payment.order.completed?
+
+    # Most likely the payment is already captured, so we don't need to capture it again.
+    return false if payment.completed?
+
+    payment.pending?
+  end
+
+  # Spree has different refund logic, called credit. We use cancel as refund for now, but only for Vattanac/True Money.
+  # In the future, we can adopt Spree's credit logic instead of cancel if needed.
+  #
+  # The flow is as follows: payment paid -> order fails -> cancel (refund) -> end.
+  def can_cancel?(payment)
+    return false unless payment.vattanac_mini_app_payment? || payment.true_money_payment?
+
+    # Cancel action is triggered when an order fails to complete.
+    # So if the order somehow completes, we do not need to cancel the payment.
+    return false if payment.order.completed?
+
+    # Most likely the payment is already canceled/voided, so we don't need to cancel it again.
+    return false if payment.void?
+
+    payment.completed?
+  end
+
+  # The flow is as follows: payment authorized -> order failed -> void (release held payment) -> end.
+  def can_void?(payment)
+    payment.pending?
   end
 end

--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -1,3 +1,17 @@
+# Note for process! & capture! method:
+#
+# Original process! & capture! calls started_processing! to move state
+# [:checkout, :pending, :completed, :processing] → :processing.
+#
+# When gateway call fails, handle_response calls send(:failure) which transitions
+# the payment to :failed state. This happens BEFORE the GatewayError is raised,
+# so when Sidekiq retries the job, the payment is already in :failed state.
+#
+# The :started_processing event doesn't allow transition from :failed → :processing,
+# so we need to reset the state back to :checkout first via reset_for_retry!
+#
+# This allows process! or capture! to be retried by Sidekiq or by admin via /fire after connection errors
+# or other transient gateway failures.
 module Vpago
   module PaymentDecorator
     def self.prepended(base)
@@ -11,12 +25,23 @@ module Vpago
                     :process_payment_url,
                     :success_deeplink_url,
                     to: :url_constructor
+
+      # Add state machine event for payment retry
+      base.state_machine.event :reset_for_retry do
+        transition from: %i[failed], to: :checkout
+      end
     end
 
-    # override:
-    # to give payment another chance to re-process, even if it failed.
+    # override
     def process!
-      update!(state: :checkout) if processing? || send(:has_invalid_state?)
+      reset_for_retry! if failed?
+
+      super
+    end
+
+    # override
+    def capture!(amount = nil)
+      reset_for_retry! if failed?
 
       super
     end

--- a/app/services/vpago/payment_processable.rb
+++ b/app/services/vpago/payment_processable.rb
@@ -1,22 +1,20 @@
 module Vpago
   module PaymentProcessable
-    def cancel_pre_auth(reason_code, reason_message)
-      log_process('cancel_pre_auth') do
-        @payment.void_transaction!
-        user_informer.payment_is_refunded(
-          processing: false,
-          reason_code: reason_code,
-          reason_message: reason_message
-        )
+    def enqueue_capture_payment_if_available!
+      Vpago::PaymentCapturerJob.perform_later(@payment.id) if available_actions.include?('capture')
+    end
+
+    def enqueue_void_or_cancel_payment_if_available!
+      if available_actions.include?('void')
+        Vpago::PaymentVoiderJob.perform_later(@payment.id)
+      elsif available_actions.include?('cancel')
+        Vpago::PaymentCancelerJob.perform_later(@payment.id)
       end
     end
 
-    # Allows canceling pre-authorization if:
-    # 1. The payment is pending or authorized.
-    # 2. Pre-auth is enabled, ensuring funds can be released to user if processing fails.
-    #    PaymentProcessor is usually called after payment is made, so canceling pre-auth typically works.
-    def can_cancel_pre_auth?
-      @payment.pending? || @payment.payment_method.enable_pre_auth? || @payment.vattanac_mini_app_payment? || @payment.true_money_payment?
+    # To check available actions, see app/models/spree/vpago_payment_source.rb
+    def available_actions
+      @payment.actions
     end
 
     def extract_completer_failure_reason_code(error)

--- a/app/services/vpago/payment_processor.rb
+++ b/app/services/vpago/payment_processor.rb
@@ -19,10 +19,15 @@ module Vpago
     end
 
     def call!
-      process_payment!
+      process_payment! if available_actions.include?('process')
       process_order! if @payment.completed? || @payment.pending?
     rescue Spree::Core::GatewayError => e
-      return handle_payment_failure(:unable_to_connect_to_gateway, e.message) if e.message == Spree.t(:unable_to_connect_to_gateway)
+      if e.message == Spree.t(:unable_to_connect_to_gateway)
+        user_informer.payment_is_retrying(processing: true)
+
+        # Re-raise to trigger Sidekiq retry mechanism.
+        raise
+      end
 
       handle_payment_failure(:gateway_error, e.message)
     rescue StateMachines::InvalidTransition => e
@@ -39,6 +44,9 @@ module Vpago
       end
     end
 
+    # If this job retries, we run this method/completer again even if the order is already completed.
+    # This ensures flow consistency. The completer will return success & this method will call handle_order_process_completed,
+    # which will enqueue a capture payment if available.
     def process_order!
       log_process('process_order!') do
         user_informer.order_is_processing(processing: true)
@@ -55,7 +63,7 @@ module Vpago
 
     def handle_order_process_completed
       log_process('handle_order_process_completed') do
-        Vpago::PaymentCapturerJob.perform_later(@payment.id) if @payment.pending?
+        enqueue_capture_payment_if_available!
         user_informer.order_is_completed(processing: false)
       end
     end
@@ -63,12 +71,12 @@ module Vpago
     def handle_order_process_failure(reason_code, reason_message = nil)
       log_process('handle_order_process_failure', reason_code, reason_message) do
         user_informer.order_process_failed(
-          processing: can_cancel_pre_auth?,
+          processing: false,
           reason_code: reason_code,
           reason_message: reason_message
         )
 
-        cancel_pre_auth(reason_code, reason_message) if can_cancel_pre_auth?
+        enqueue_void_or_cancel_payment_if_available!
         failure(reason_message)
       end
     end
@@ -76,12 +84,12 @@ module Vpago
     def handle_payment_failure(reason_code, reason_message)
       log_process('handle_payment_failure', reason_code, reason_message) do
         user_informer.payment_process_failed(
-          processing: can_cancel_pre_auth?,
+          processing: false,
           reason_code: reason_code,
           reason_message: reason_message
         )
 
-        cancel_pre_auth(reason_code, reason_message) if can_cancel_pre_auth?
+        enqueue_void_or_cancel_payment_if_available!
         failure(reason_message)
       end
     end

--- a/app/services/vpago/user_informers/firebase.rb
+++ b/app/services/vpago/user_informers/firebase.rb
@@ -10,10 +10,10 @@ module Vpago
       end
 
       def payment_is_processing(processing:) = notify(:payment_is_processing, processing)
+      def payment_is_retrying(processing:) = notify(:payment_is_retrying, processing)
       def order_is_processing(processing:) = notify(:order_is_processing, processing)
       def order_is_completed(processing:) = notify(:order_is_completed, processing)
       def order_process_failed(processing:, reason_code:, reason_message: nil) = notify(:order_process_failed, processing, reason_code, reason_message)
-      def payment_is_refunded(processing:, reason_code:, reason_message: nil) = notify(:payment_is_refunded, processing, reason_code, reason_message)
       def payment_process_failed(processing:, reason_code:, reason_message: nil) = notify(:payment_process_failed, processing, reason_code, reason_message)
 
       def notify(message_code, processing, reason_code = nil, reason_message = nil)

--- a/app/views/spree/vpago_payments/processing.html.erb
+++ b/app/views/spree/vpago_payments/processing.html.erb
@@ -23,6 +23,12 @@
         document.getElementById("processing").innerText = processing ? "Processing..." : "No more process.";
         document.getElementById("reason_message").innerText = reasonMessage;
       },
+      onPaymentIsRetrying: function (orderState, paymentState, processing, reasonCode, reasonMessage) {
+        document.getElementById("status").innerText = "Payment is retrying";
+        document.getElementById("reason_code").innerText = reasonCode;
+        document.getElementById("processing").innerText = processing ? "Retrying..." : "No more process.";
+        document.getElementById("reason_message").innerText = reasonMessage;
+      },
       onOrderIsProcessing: function (orderState, paymentState, processing, reasonCode, reasonMessage) {
         document.getElementById("status").innerText = "Order is processing";
         document.getElementById("reason_code").innerText = reasonCode;
@@ -40,12 +46,6 @@
         document.getElementById("reason_code").innerText = reasonCode;
         document.getElementById("processing").innerText = processing ? "Processing..." : "No more process.";
         document.getElementById("reason_message").innerText = reasonMessage;
-      },
-      onPaymentIsRefunded: function (orderState, paymentState, processing, reasonCode, reasonMessage) {
-        document.getElementById("status").innerText = "Payment is refunded";
-        document.getElementById("reason_code").innerText = reasonCode;
-        document.getElementById("processing").innerText = processing ? "Processing..." : "No more process.";
-        document.getElementById("reason_message").innerText = reasonMessage
       },
       onPaymentProcessFailed: function (orderState, paymentState, processing, reasonCode, reasonMessage) {
         document.getElementById("status").innerText = "Payment process failed";

--- a/spec/jobs/vpago/payment_canceler_job_spec.rb
+++ b/spec/jobs/vpago/payment_canceler_job_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Vpago::PaymentCancelerJob, type: :job do
+  let(:order) { create(:order_with_line_items, state: :payment) }
+  let(:payment) { create(:vattanac_mini_app_payment, number: 'PJ0MYD2Y', order: order) }
+
+  it 'is enqueued on the payment_processing queue' do
+    expect {
+      described_class.perform_later(payment.id)
+    }.to have_enqueued_job(described_class)
+      .with(payment.id)
+      .on_queue('payment_processing')
+  end
+
+  describe '#perform' do
+    context 'when cancel action is available' do
+      before do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_cancel?).and_return(true)
+      end
+
+      it 'calls cancel! on the payment' do
+        expect_any_instance_of(Spree::Payment).to receive(:cancel!)
+        described_class.new.perform(payment.id)
+      end
+    end
+
+    context 'when cancel action is not available' do
+      before do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_cancel?).and_return(false)
+      end
+
+      it 'does not call cancel!' do
+        expect_any_instance_of(Spree::Payment).not_to receive(:cancel!)
+        described_class.new.perform(payment.id)
+      end
+    end
+  end
+end

--- a/spec/jobs/vpago/payment_capturer_job_spec.rb
+++ b/spec/jobs/vpago/payment_capturer_job_spec.rb
@@ -12,32 +12,29 @@ RSpec.describe Vpago::PaymentCapturerJob, type: :job do
       .on_queue('payment_processing')
   end
 
-  context 'when payment is pending' do
-    before do
-      # Stub `pending?` to return true so `capture!` is called
-      allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(true)
-      expect(payment.state).to eq 'checkout'
-    end
-  
-    it 'calls capture! on the payment if it is pending' do
-      expect_any_instance_of(Spree::Payment).to receive(:capture!).and_call_original
-      described_class.new.perform(payment.id)
-  
-      expect(payment.reload.state).to eq 'completed'
-    end    
-  end
+  describe '#perform' do
+    context 'when capture action is available' do
+      before do
+        allow(payment).to receive(:actions).and_return(['capture'])
+        allow(Spree::Payment).to receive(:find).with(payment.id).and_return(payment)
+      end
 
-  context 'when payment is not pending' do
-    before do
-      allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(false)
-      expect(payment.state).to eq 'checkout'
+      it 'calls capture! on the payment' do
+        expect(payment).to receive(:capture!)
+        described_class.new.perform(payment.id)
+      end
     end
 
-    it 'does not call capture!' do
-      expect_any_instance_of(Spree::Payment).not_to receive(:capture!)
-      described_class.new.perform(payment.id)
+    context 'when capture action is not available' do
+      before do
+        allow(payment).to receive(:actions).and_return([])
+        allow(Spree::Payment).to receive(:find).with(payment.id).and_return(payment)
+      end
 
-      expect(payment.reload.state).to eq 'checkout'
+      it 'does not call capture!' do
+        expect(payment).not_to receive(:capture!)
+        described_class.new.perform(payment.id)
+      end
     end
   end
 end

--- a/spec/jobs/vpago/payment_processor_job_spec.rb
+++ b/spec/jobs/vpago/payment_processor_job_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Vpago::PaymentProcessorJob, type: :job do
 
   describe '#perform' do
     it 'find payment & call process payment' do
-      expect(Spree::Payment).to receive(:find_by).with(number: payment.number).and_return(payment)
+      expect(Spree::Payment).to receive(:find_by!).with({ number: payment.number }).and_return(payment)
       expect(Vpago::PaymentProcessor).to receive(:new).with(payment: payment).and_return(processor)
       expect(processor).to receive(:call)
 
-      Vpago::PaymentProcessorJob.perform_now(payment_number: payment.number)
+      Vpago::PaymentProcessorJob.perform_now({ payment_number: payment.number })
     end
   end
 end

--- a/spec/jobs/vpago/payment_voider_job_spec.rb
+++ b/spec/jobs/vpago/payment_voider_job_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe Vpago::PaymentVoiderJob, type: :job do
+  let(:order) { create(:order_with_line_items, state: :payment) }
+  let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order) }
+
+  it 'is enqueued on the payment_processing queue' do
+    expect {
+      described_class.perform_later(payment.id)
+    }.to have_enqueued_job(described_class)
+      .with(payment.id)
+      .on_queue('payment_processing')
+  end
+
+  describe '#perform' do
+    context 'when void action is available' do
+      before do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_void?).and_return(true)
+      end
+
+      it 'calls void_transaction! on the payment' do
+        expect_any_instance_of(Spree::Payment).to receive(:void_transaction!)
+        described_class.new.perform(payment.id)
+      end
+    end
+
+    context 'when void action is not available' do
+      before do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_void?).and_return(false)
+      end
+
+      it 'does not call void_transaction!' do
+        expect_any_instance_of(Spree::Payment).not_to receive(:void_transaction!)
+        described_class.new.perform(payment.id)
+      end
+    end
+  end
+end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -40,11 +40,56 @@ RSpec.describe Spree::Payment, type: :model do
 
   describe '#process!' do
     let(:order) { create(:order_with_line_items, state: :payment) }
-    let(:payment_method) { create(:payway_v2_gateway, preferred_host: 'https://bad-url') }
+    let(:payment_method) { create(:payway_v2_gateway) }
     let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order, payment_method: payment_method) }
 
+    context 'when payment is in processing state' do
+      before do
+        # Mock purchase! to simulate a payment attempt
+        allow(payment).to receive(:purchase!)
+      end
+
+      it 'does not reset payment when already processing' do
+        payment.update!(state: 'processing')
+        expect(payment).to_not receive(:reset_for_retry!)
+
+        payment.process!
+      end
+
+      it 'calls purchase! without reset' do
+        payment.update!(state: 'processing')
+        expect(payment).to receive(:purchase!).ordered
+        
+        payment.process!
+      end
+    end
+
+    context 'when payment is in failed state' do
+      before do
+        # Mock purchase! to simulate a payment attempt
+        allow(payment).to receive(:purchase!)
+      end
+
+      it 'resets payment for retry before processing' do
+        payment.update!(state: 'failed')
+        expect(payment).to receive(:reset_for_retry!).and_call_original
+        
+        payment.process!
+        # State should be checkout after reset_for_retry!, then purchase! is called
+        expect(payment.state).to eq('checkout')
+      end
+
+      it 'calls reset_for_retry! then purchase!' do
+        payment.update!(state: 'failed')
+        expect(payment).to receive(:reset_for_retry!).ordered.and_call_original
+        expect(payment).to receive(:purchase!).ordered
+        
+        payment.process!
+      end
+    end
+
     context 'when faraday connection error raised during process' do
-      it 'capture faraday error and rethow as gateway error (order only rescue gateway error)' do
+      it 'captures faraday error and rethrows as gateway error (order only rescues gateway error)' do
         expect(payment).to receive(:gateway_error).and_call_original do |error|
           expect(error).to be_a(ActiveMerchant::ConnectionError)
           expect(error.triggering_exception).to be_a(Faraday::ConnectionFailed)
@@ -55,6 +100,264 @@ RSpec.describe Spree::Payment, type: :model do
             payment.process!
           }.to raise_error(Spree::Core::GatewayError, Spree.t(:unable_to_connect_to_gateway))
         end
+      end
+    end
+  end
+
+  describe '#capture!' do
+    let(:order) { create(:order_with_line_items, state: :payment) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order, payment_method: payment_method) }
+
+    context 'when payment is in processing state' do
+      before do
+        # Mock protect_from_connection_error to do nothing
+        allow(payment).to receive(:protect_from_connection_error).and_return(nil)
+      end
+
+      it 'does not reset payment when already processing' do
+        payment.update!(state: 'processing')
+        expect(payment).to_not receive(:reset_for_retry!)
+
+        payment.capture!
+
+        expect(payment.reload.state).to eq('processing')
+      end
+
+      it 'calls capture without reset' do
+        payment.update!(state: 'processing')
+        expect(payment).to receive(:protect_from_connection_error).ordered
+
+        payment.capture!
+
+        # capture will start processing again.
+        expect(payment.reload.state).to eq('processing')
+      end
+    end
+
+    context 'when payment is in failed state' do
+      before do
+        # Mock protect_from_connection_error to do nothing
+        allow(payment).to receive(:protect_from_connection_error).and_return(nil)
+      end
+
+      it 'resets payment for retry before capturing' do
+        payment.update!(state: 'failed')
+        expect(payment).to receive(:reset_for_retry!).and_call_original
+        
+        payment.capture!
+
+        # capture will start processing again.
+        expect(payment.reload.state).to eq('processing')
+      end
+
+      it 'calls reset_for_retry! then proceeds with capture' do
+        payment.update!(state: 'failed')
+        expect(payment).to receive(:reset_for_retry!).ordered.and_call_original
+        expect(payment).to receive(:protect_from_connection_error).ordered
+        
+        payment.capture!
+        
+        # capture will start processing again.
+        expect(payment.reload.state).to eq('processing')
+      end
+    end
+
+    context 'when faraday connection error raised during capture' do
+      it 'capture faraday error and rethrow as gateway error (order only rescue gateway error)' do
+        # Simulate the actual capture! flow by having protect_from_connection_error raise the error
+        allow(payment).to receive(:protect_from_connection_error).and_call_original
+        allow(payment.payment_method).to receive(:capture).and_raise(Faraday::ConnectionFailed.new('Connection failed'))
+        
+        expect(payment).to receive(:gateway_error).and_call_original do |error|
+          expect(error).to be_a(ActiveMerchant::ConnectionError)
+          expect(error.triggering_exception).to be_a(Faraday::ConnectionFailed)
+        end
+
+        expect {
+          payment.capture!
+        }.to raise_error(Spree::Core::GatewayError, Spree.t(:unable_to_connect_to_gateway))
+
+        expect(payment.reload.state).to eq('failed')
+      end
+    end
+  end
+
+  describe '#reset_for_retry!' do
+    let(:order) { create(:order_with_line_items, state: :payment) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:payment) { create(:payway_v2_payment, order: order, payment_method: payment_method) }
+
+    context 'when payment is in failed state' do
+      it 'transitions payment from failed to checkout' do
+        payment.update!(state: 'failed')
+        
+        expect {
+          payment.reset_for_retry!
+        }.to change { payment.state }.from('failed').to('checkout')
+      end
+    end
+
+    context 'when payment is not in failed state' do
+      it 'does not transition from processing state' do
+        payment.update!(state: 'processing')
+        
+        expect {
+          payment.reset_for_retry!
+        }.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it 'does not transition from completed state' do
+        payment.update!(state: 'completed')
+        
+        expect {
+          payment.reset_for_retry!
+        }.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it 'does not transition from checkout state' do
+        payment.update!(state: 'checkout')
+        
+        expect {
+          payment.reset_for_retry!
+        }.to raise_error(StateMachines::InvalidTransition)
+      end
+
+      it 'does not transition from pending state' do
+        payment.update!(state: 'pending')
+        
+        expect {
+          payment.reset_for_retry!
+        }.to raise_error(StateMachines::InvalidTransition)
+      end
+    end
+  end
+
+  describe '#protect_from_connection_error' do
+    let(:order) { create(:order_with_line_items, state: :payment) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:payment) { create(:payway_v2_payment, order: order, payment_method: payment_method) }
+
+    context 'when ActiveMerchant::ConnectionError is raised' do
+      it 'calls failure! and gateway_error' do
+        # ActiveMerchant::ConnectionError requires message and response parameters
+        error = ActiveMerchant::ConnectionError.new('Connection failed', nil)
+        
+        expect(payment).to receive(:failure!).ordered
+        expect(payment).to receive(:gateway_error).with(error).ordered.and_call_original
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+      end
+
+      it 'transitions payment to failed state' do
+        payment.update!(state: 'processing')
+        # ActiveMerchant::ConnectionError requires message and response parameters
+        error = ActiveMerchant::ConnectionError.new('Connection failed', nil)
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+        
+        expect(payment.reload.state).to eq('failed')
+      end
+    end
+
+    context 'when Faraday::ConnectionFailed is raised' do
+      it 'wraps error in ActiveMerchant::ConnectionError and calls failure! and gateway_error' do
+        faraday_error = Faraday::ConnectionFailed.new('Network error')
+        
+        expect(payment).to receive(:failure!).ordered
+        expect(payment).to receive(:gateway_error).ordered do |error|
+          expect(error).to be_a(ActiveMerchant::ConnectionError)
+          expect(error.message).to eq('Network error')
+          expect(error.triggering_exception).to eq(faraday_error)
+        end.and_call_original
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise faraday_error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+      end
+
+      it 'transitions payment to failed state' do
+        payment.update!(state: 'processing')
+        faraday_error = Faraday::ConnectionFailed.new('Network error')
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise faraday_error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+        
+        expect(payment.reload.state).to eq('failed')
+      end
+    end
+
+    context 'when Faraday::TimeoutError is raised' do
+      it 'wraps error in ActiveMerchant::ConnectionError and calls failure! and gateway_error' do
+        timeout_error = Faraday::TimeoutError.new('Request timeout')
+        
+        expect(payment).to receive(:failure!).ordered
+        expect(payment).to receive(:gateway_error).ordered do |error|
+          expect(error).to be_a(ActiveMerchant::ConnectionError)
+          expect(error.message).to eq('Request timeout')
+          expect(error.triggering_exception).to eq(timeout_error)
+        end.and_call_original
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise timeout_error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+      end
+
+      it 'transitions payment to failed state' do
+        payment.update!(state: 'processing')
+        timeout_error = Faraday::TimeoutError.new('Request timeout')
+        
+        expect {
+          payment.protect_from_connection_error do
+            raise timeout_error
+          end
+        }.to raise_error(Spree::Core::GatewayError)
+        
+        expect(payment.reload.state).to eq('failed')
+      end
+    end
+
+    context 'when no error is raised' do
+      it 'executes the block successfully' do
+        result = payment.protect_from_connection_error do
+          'success'
+        end
+        
+        expect(result).to eq('success')
+      end
+
+      it 'does not call failure! or gateway_error' do
+        expect(payment).to_not receive(:failure!)
+        expect(payment).to_not receive(:gateway_error)
+        
+        payment.protect_from_connection_error do
+          'success'
+        end
+      end
+    end
+
+    context 'when other errors are raised' do
+      it 'does not rescue the error' do
+        expect {
+          payment.protect_from_connection_error do
+            raise StandardError, 'Other error'
+          end
+        }.to raise_error(StandardError, 'Other error')
       end
     end
   end

--- a/spec/models/spree/vpago_payment_source_spec.rb
+++ b/spec/models/spree/vpago_payment_source_spec.rb
@@ -1,24 +1,281 @@
 require 'spec_helper'
 
 RSpec.describe Spree::VpagoPaymentSource, type: :model do
-  let(:gateway) { create(:payway_gateway, auto_capture: true) }
-  let(:payment_source) { create(:payway_payment_source, payment_method: gateway) }
-  
-  # describe 'validates presence of updated_reason for update' do
-  #   it 'does not require for new record' do
-  #     source = build(:payway_payment_source) 
-  #     expect(source.valid?).to eq true
-  #   end
+  describe 'associations' do
+    it { should belong_to(:payment_method).optional }
+    it { should have_one(:payment) }
+  end
 
-  #   it 'requires to be presence when it is a new record' do
-  #     source = create(:payway_payment_source)
-  #     source.payment_status = 'success'
-  #     source.updated_reason = nil
+  describe '#actions' do
+    let(:payment_source) { build(:payway_payment_source) }
 
-  #     expect(source.valid?).to eq false
-  #     expect(source.errors[:updated_reason].to_a).to eq ["can't be blank"]
-  #   end
+    it 'returns available actions' do
+      expect(payment_source.actions).to eq(%w[open_checkout process capture void cancel])
+    end
+  end
 
-  # end
+  describe '#can_open_checkout?' do
+    let(:order) { create(:order) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+    let!(:payment) { Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first }
+    let(:payment_source) { payment.source }
 
+    context 'when payment is in checkout state' do
+      before { payment.update!(state: 'checkout') }
+
+      it 'returns true' do
+        expect(payment_source.can_open_checkout?(payment)).to be true
+      end
+    end
+
+    context 'when payment is not in checkout state' do
+      before { payment.update!(state: 'processing') }
+
+      it 'returns false' do
+        expect(payment_source.can_open_checkout?(payment)).to be false
+      end
+    end
+  end
+
+  describe '#can_process?' do
+    let(:order) { create(:order) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+    let!(:payment) { Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first }
+    let(:payment_source) { payment.source }
+
+    context 'when payment is in checkout state' do
+      before { payment.update!(state: 'checkout') }
+
+      it 'returns true' do
+        expect(payment_source.can_process?(payment)).to be true
+      end
+    end
+
+    context 'when payment is in processing state' do
+      before { payment.update!(state: 'processing') }
+
+      it 'returns true' do
+        expect(payment_source.can_process?(payment)).to be true
+      end
+    end
+
+    context 'when payment is completed' do
+      before { payment.update!(state: 'completed') }
+
+      it 'returns false' do
+        expect(payment_source.can_process?(payment)).to be false
+      end
+    end
+
+    context 'when payment is pending' do
+      before { payment.update!(state: 'pending') }
+
+      it 'returns false' do
+        expect(payment_source.can_process?(payment)).to be false
+      end
+    end
+  end
+
+  describe '#can_capture?' do
+    let(:order) { create(:order) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+    let!(:payment) { Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first }
+    let(:payment_source) { payment.source }
+
+    context 'when order is completed and payment is pending' do
+      before do
+        order.update!(state: 'complete', completed_at: Time.current)
+        payment.update!(state: 'pending')
+      end
+
+      it 'returns true' do
+        expect(payment_source.can_capture?(payment)).to be true
+      end
+    end
+
+    context 'when order is not completed' do
+      before do
+        order.update!(state: 'payment')
+        payment.update!(state: 'pending')
+      end
+
+      it 'returns false' do
+        expect(payment_source.can_capture?(payment)).to be false
+      end
+    end
+
+    context 'when payment is already completed' do
+      before do
+        order.update!(state: 'complete', completed_at: Time.current)
+        payment.update!(state: 'completed')
+      end
+
+      it 'returns false' do
+        expect(payment_source.can_capture?(payment)).to be false
+      end
+    end
+
+    context 'when payment is not pending' do
+      before do
+        order.update!(state: 'complete', completed_at: Time.current)
+        payment.update!(state: 'checkout')
+      end
+
+      it 'returns false' do
+        expect(payment_source.can_capture?(payment)).to be false
+      end
+    end
+  end
+
+  describe '#can_cancel?' do
+    let(:order) { create(:order) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+    let!(:payment) { Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first }
+    let(:payment_source) { payment.source }
+
+    context 'with Vattanac Mini App payment' do
+      let(:payment_method) { create(:vattanac_mini_app_gateway) }
+
+      context 'when order is not completed and payment is completed' do
+        before do
+          order.update!(state: 'payment')
+          payment.update!(state: 'completed')
+        end
+
+        it 'returns true' do
+          expect(payment_source.can_cancel?(payment)).to be true
+        end
+      end
+
+      context 'when order is completed' do
+        before do
+          order.update!(state: 'complete', completed_at: Time.current)
+          payment.update!(state: 'completed')
+        end
+
+        it 'returns false' do
+          expect(payment_source.can_cancel?(payment)).to be false
+        end
+      end
+
+      context 'when payment is void' do
+        before do
+          order.update!(state: 'payment')
+          payment.update!(state: 'void')
+        end
+
+        it 'returns false' do
+          expect(payment_source.can_cancel?(payment)).to be false
+        end
+      end
+
+      context 'when payment is not completed' do
+        before do
+          order.update!(state: 'payment')
+          payment.update!(state: 'pending')
+        end
+
+        it 'returns false' do
+          expect(payment_source.can_cancel?(payment)).to be false
+        end
+      end
+    end
+
+    context 'with True Money payment' do
+      let(:payment_method) { create(:true_money_gateway) }
+
+      context 'when order is not completed and payment is completed' do
+        before do
+          order.update!(state: 'payment')
+          payment.update!(state: 'completed')
+        end
+
+        it 'returns true' do
+          expect(payment_source.can_cancel?(payment)).to be true
+        end
+      end
+    end
+
+    context 'with non-cancelable payment method' do
+      let(:payment_method) { create(:payway_v2_gateway) }
+
+      before do
+        order.update!(state: 'payment')
+        payment.update!(state: 'completed')
+      end
+
+      it 'returns false' do
+        expect(payment_source.can_cancel?(payment)).to be false
+      end
+    end
+  end
+
+  describe '#can_void?' do
+    let(:order) { create(:order) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+    let!(:payment) { Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first }
+    let(:payment_source) { payment.source }
+
+    context 'when payment is pending' do
+      before { payment.update!(state: 'pending') }
+
+      it 'returns true' do
+        expect(payment_source.can_void?(payment)).to be true
+      end
+    end
+
+    context 'when payment is not pending' do
+      before { payment.update!(state: 'completed') }
+
+      it 'returns false' do
+        expect(payment_source.can_void?(payment)).to be false
+      end
+    end
+  end
+
+  describe 'creating payment source via FindOrCreate service' do
+    let(:order) { create(:order) }
+    let(:payment_method) { create(:payway_v2_gateway) }
+    let(:params) { { payment_method_id: payment_method.id, payment_option: 'abapay_khqr' } }
+
+    context 'when creating a new payment with source' do
+      it 'creates a payment source with correct attributes' do
+        result = Vpago::Payments::FindOrCreate.call(order: order, params: params)
+
+        expect(result.success?).to be true
+        
+        payment = order.payments.first
+        source = payment.source
+
+        expect(source).to be_a(Spree::VpagoPaymentSource)
+        expect(source.payment_option).to eq('abapay_khqr')
+        expect(source.payment_method_id).to eq(payment_method.id)
+        expect(source.user_id).to eq(order.user&.id)
+      end
+    end
+
+    context 'when finding existing payment source' do
+      let!(:existing_payment) do
+        Vpago::Payments::FindOrCreate.call(order: order, params: params).value[:order].payments.first
+      end
+
+      before do
+        existing_payment.update!(state: 'checkout')
+      end
+
+      it 'reuses the existing payment source' do
+        expect(order.payments.count).to eq(1)
+        
+        result = Vpago::Payments::FindOrCreate.call(order: order, params: params)
+
+        expect(result.success?).to be true
+        expect(order.payments.count).to eq(1)
+        expect(order.payments.first.source.id).to eq(existing_payment.source.id)
+      end
+    end
+  end
 end

--- a/spec/services/vpago/payment_processable_spec.rb
+++ b/spec/services/vpago/payment_processable_spec.rb
@@ -1,0 +1,139 @@
+require 'spec_helper'
+
+RSpec.describe Vpago::PaymentProcessable do
+  include ActiveJob::TestHelper
+
+  let(:user_informer) { ::Vpago::UserInformers::Firebase.new(payment.order) }
+
+  let(:order) { create(:order_with_line_items, state: :payment) }
+  let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order) }
+
+  # payment processor include this module.
+  subject { Vpago::PaymentProcessor.new(payment: payment) }
+
+  before do
+    allow(subject).to receive(:user_informer).and_return(user_informer)
+  end
+
+  describe '#enqueue_capture_payment_if_available!' do
+    context 'when capture action is available' do
+      it 'enqueues PaymentCapturerJob' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_capture?).and_return(true)
+
+        expect(Vpago::PaymentCapturerJob).to receive(:perform_later).with(payment.id)
+
+        subject.send(:enqueue_capture_payment_if_available!)
+      end
+    end
+
+    context 'when capture action is not available' do
+      it 'does not enqueue PaymentCapturerJob' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_capture?).and_return(false)
+
+        expect(Vpago::PaymentCapturerJob).not_to receive(:perform_later)
+
+        subject.send(:enqueue_capture_payment_if_available!)
+      end
+    end
+  end
+
+  describe '#enqueue_void_or_cancel_payment_if_available!' do
+    context 'when void action is available' do
+      it 'enqueues PaymentVoiderJob' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_void?).and_return(true)
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_cancel?).and_return(false)
+
+        expect(Vpago::PaymentVoiderJob).to receive(:perform_later).with(payment.id)
+        expect(Vpago::PaymentCancelerJob).not_to receive(:perform_later)
+
+        subject.send(:enqueue_void_or_cancel_payment_if_available!)
+      end
+    end
+
+    context 'when cancel action is available' do
+      it 'enqueues PaymentCancelerJob' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_void?).and_return(false)
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_cancel?).and_return(true)
+
+        expect(Vpago::PaymentVoiderJob).not_to receive(:perform_later)
+        expect(Vpago::PaymentCancelerJob).to receive(:perform_later).with(payment.id)
+
+        subject.send(:enqueue_void_or_cancel_payment_if_available!)
+      end
+    end
+
+    context 'when neither void nor cancel action is available' do
+      it 'does not enqueue any job' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_void?).and_return(false)
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_cancel?).and_return(false)
+
+        expect(Vpago::PaymentVoiderJob).not_to receive(:perform_later)
+        expect(Vpago::PaymentCancelerJob).not_to receive(:perform_later)
+
+        subject.send(:enqueue_void_or_cancel_payment_if_available!)
+      end
+    end
+  end
+
+  describe '#extract_completer_failure_reason_code' do
+    context 'when some items are out of stock' do      
+      before do
+        allow_any_instance_of(Spree::LineItem).to receive(:sufficient_stock?).and_return(false)
+      end
+
+      it 'returns reason code :some_line_items_are_out_of_stock' do
+        completer = Spree::Checkout::Complete.new.call(order: order)
+        expect(subject.send(:extract_completer_failure_reason_code, completer.error)).to eq :some_line_items_are_out_of_stock
+      end
+    end
+
+    context 'when some items are discontinued' do      
+      before do
+        allow_any_instance_of(Spree::Variant).to receive(:discontinued?).and_return(true)
+      end
+
+      it 'returns reason code :some_variants_are_discontinued' do
+        completer = Spree::Checkout::Complete.new.call(order: order)
+        expect(subject.send(:extract_completer_failure_reason_code, completer.error)).to eq :some_variants_are_discontinued
+      end
+    end
+
+    context 'when error message is neither of above cases' do
+      it 'returns reason code :unable_to_complete_order' do
+        expect(subject.send(:extract_completer_failure_reason_code, { :base => nil })).to eq :unable_to_complete_order
+        expect(subject.send(:extract_completer_failure_reason_code, '')).to eq :unable_to_complete_order
+        expect(subject.send(:extract_completer_failure_reason_code, {})).to eq :unable_to_complete_order
+        expect(subject.send(:extract_completer_failure_reason_code, nil)).to eq :unable_to_complete_order
+      end
+    end
+  end
+
+  describe '#available_actions' do
+    it 'returns payment actions' do
+      expect(payment).to receive(:actions).and_return(['process', 'capture'])
+
+      result = subject.send(:available_actions)
+
+      expect(result).to eq(['process', 'capture'])
+    end
+  end
+
+  describe '#success?' do
+    it 'returns true when no error' do
+      expect(subject.success?).to be true
+    end
+
+    it 'returns false when there is an error' do
+      subject.send(:failure, 'Some error')
+      expect(subject.success?).to be false
+    end
+  end
+
+  describe '#failure' do
+    it 'sets the error' do
+      subject.send(:failure, 'Some error message')
+      expect(subject.success?).to be false
+      expect(subject.instance_variable_get(:@error)).to eq 'Some error message'
+    end
+  end
+end

--- a/spec/services/vpago/payment_processor_spec.rb
+++ b/spec/services/vpago/payment_processor_spec.rb
@@ -15,12 +15,26 @@ RSpec.describe Vpago::PaymentProcessor do
   end
 
   describe '#call' do
-    context 'when payment is completed' do
-      it 'process_payment! then process_order!' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#call! for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#call! for payment_number: #{payment.number} in")).once
-
+    context 'when process action is not available' do
+      it 'skips process_payment! && calls process_order!' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(false)
         allow(payment).to receive(:completed?).and_return(true)
+
+        expect(subject).not_to receive(:process_payment!)
+        expect(subject).to receive(:process_order!)
+
+        subject.call
+      end
+    end
+
+    context 'when process action is available and payment becomes completed' do
+      it 'calls process_payment! then process_order!' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
+
+        # Simulate process_payment! changing payment state to completed
+        allow(subject).to receive(:process_payment!) do
+          allow(payment).to receive(:completed?).and_return(true)
+        end
 
         expect(subject).to receive(:process_payment!)
         expect(subject).to receive(:process_order!)
@@ -29,13 +43,28 @@ RSpec.describe Vpago::PaymentProcessor do
       end
     end
 
-    context 'when payment is not completed' do
-      it 'did not call process_order!' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#call! for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#call! for payment_number: #{payment.number} in")).once
+    context 'when process action is available and payment becomes pending' do
+      it 'calls process_payment! then process_order!' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
+        allow(payment).to receive(:completed?).and_return(false)
+        allow(payment).to receive(:pending?).and_return(false, true)
 
+        allow(subject).to receive(:process_payment!)
+
+        expect(subject).to receive(:process_payment!)
+        expect(subject).to receive(:process_order!)
+
+        subject.call
+      end
+    end
+
+    context 'when process action is available but payment state does not change' do
+      it 'calls process_payment! but does not call process_order!' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
         allow(payment).to receive(:completed?).and_return(false)
         allow(payment).to receive(:pending?).and_return(false)
+
+        allow(subject).to receive(:process_payment!)
 
         expect(subject).to receive(:process_payment!)
         expect(subject).not_to receive(:process_order!)
@@ -44,58 +73,51 @@ RSpec.describe Vpago::PaymentProcessor do
       end
     end
 
-    context 'when process_payment! raise Spree::Core::GatewayError or StateMachines::InvalidTransition' do
-      it 'rescue the error & call handle_payment_failure' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#call! for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#call! for payment_number: #{payment.number} in")).once
+    context 'when process_payment! raises Spree::Core::GatewayError with gateway message' do
+      it 'calls payment_is_retrying and re-raises the error' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
+        allow(subject).to receive(:process_payment!).and_raise(Spree::Core::GatewayError.new(Spree.t(:unable_to_connect_to_gateway)))
 
-        allow(subject).to receive(:process_payment!).and_raise(Spree::Core::GatewayError.new('This is error'))
+        expect(user_informer).to receive(:payment_is_retrying).with(processing: true)
 
-        expect(subject).to receive(:handle_payment_failure).with(:gateway_error, 'This is error')
+        expect { subject.call }.to raise_error(Spree::Core::GatewayError)
+      end
+    end
+
+    context 'when process_payment! raises Spree::Core::GatewayError with other message' do
+      it 'calls handle_payment_failure with gateway_error' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
+        allow(subject).to receive(:process_payment!).and_raise(Spree::Core::GatewayError.new('Some other error'))
+
+        expect(subject).to receive(:handle_payment_failure).with(:gateway_error, 'Some other error')
 
         subject.call
       end
     end
 
-    context 'when process_payment! raise Spree::Core::GatewayError connecting to gateway' do
-      it 'rescue the error & call handle_payment_failure' do
-        expect(user_informer).to receive(:payment_is_processing).with(processing: true)
-        expect(subject).to receive(:handle_payment_failure).with(:unable_to_connect_to_gateway, 'Unable to connect to gateway.')
+    context 'when process_payment! raises StateMachines::InvalidTransition' do
+      it 'calls handle_payment_failure with invalid_state_machine_transition' do
+        allow_any_instance_of(Spree::VpagoPaymentSource).to receive(:can_process?).and_return(true)
 
-        VCR.use_cassette("connection_error") do
-          subject.call
-        end
+        # Mock payment.process! to raise InvalidTransition (simulating invalid state)
+        allow(subject).to receive(:process_payment!).and_raise(StateMachines::InvalidTransition.new(payment, Spree::Payment.state_machines[:state], :void))
+
+        expect(subject).to receive(:handle_payment_failure).with(:invalid_state_machine_transition, anything)
+
+        subject.call
       end
     end
   end
 
   describe '#process_payment!' do
-    context 'when payment is completed?' do
-      it 'inform user that payment is processing & trigger payment.process!' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} in")).once
+    it 'informs user that payment is processing & triggers payment.process!' do
+      expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} with args: \[]")).once
+      expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} in")).once
 
-        expect(user_informer).to receive(:payment_is_processing).with(processing: true)
-        expect(payment).to receive(:process!)
+      expect(user_informer).to receive(:payment_is_processing).with(processing: true)
+      expect(payment).to receive(:process!)
 
-        allow(payment).to receive(:completed?).and_return(true)
-
-        subject.send(:process_payment!)
-      end
-    end
-
-    context 'when payment is pending?' do
-      it 'inform user that payment is processing & trigger payment.process!' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#process_payment! for payment_number: #{payment.number} in")).once
-
-        expect(user_informer).to receive(:payment_is_processing).with(processing: true)
-        expect(payment).to receive(:process!)
-
-        allow(payment).to receive(:pending?).and_return(true)
-
-        subject.send(:process_payment!)
-      end
+      subject.send(:process_payment!)
     end
   end
 
@@ -156,191 +178,40 @@ RSpec.describe Vpago::PaymentProcessor do
   end
 
   describe '#handle_order_process_completed' do
-    context 'when pre-auth enabled or payment is authorized' do
-      before do
-        allow_any_instance_of(Spree::Payment).to receive(:pending?).and_return(true)
-      end
+    it 'enqueues capture payment if available and informs user order is completed' do
+      expect(subject).to receive(:enqueue_capture_payment_if_available!)
+      expect(user_informer).to receive(:order_is_completed).with(processing: false)
 
-      it 'capture the payment in job & inform user the order is completed!' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} in")).once
-
-        expect(Vpago::PaymentCapturerJob).to receive(:perform_later).with(payment.id).and_call_original
-        expect(user_informer).to receive(:order_is_completed).with(processing: false)
-        
-        perform_enqueued_jobs do
-          expect(payment.state).to eq 'checkout'
-          subject.send(:handle_order_process_completed)
-          expect(payment.reload.state).to eq 'completed'
-        end
-      end
-    end
-
-    context 'when pre-auth is disabled' do
-      before do
-        allow(payment).to receive(:pending?).and_return(false)
-      end
-
-      it 'inform user the order is completed directly' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} with args: \[]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_order_process_completed for payment_number: #{payment.number} in")).once
-
-        expect(payment).not_to receive(:capture!)
-        expect(user_informer).to receive(:order_is_completed).with(processing: false)
-
-        subject.send(:handle_order_process_completed)
-        expect(subject.success?).to be true
-      end
+      subject.send(:handle_order_process_completed)
+      expect(subject.success?).to be true
     end
   end
 
   describe '#handle_order_process_failure' do
-    context 'when can_cancel_pre_auth (pre-auth is enabled)' do
-      before do
-        allow(subject).to receive(:can_cancel_pre_auth?).and_return(true)
-      end
+    it 'informs user of failure, enqueues cancel/release, and marks as failure' do
+      expect(user_informer).to receive(:order_process_failed).with(
+        processing: false,
+        reason_code: :some_line_items_are_out_of_stock,
+        reason_message: 'Out of stock'
+      )
+      expect(subject).to receive(:enqueue_void_or_cancel_payment_if_available!)
 
-      it 'inform user that process order failed & call cancel_pre_auth' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_order_process_failure for payment_number: #{payment.number} with args: [:some_line_items_are_out_of_stock, \"My error message\"]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_order_process_failure for payment_number: #{payment.number} in")).once
-
-        expect(user_informer).to receive(:order_process_failed).with(processing: true, reason_code: :some_line_items_are_out_of_stock, reason_message: 'My error message')
-        expect(subject).to receive(:cancel_pre_auth).with(:some_line_items_are_out_of_stock, 'My error message')
-
-        subject.send(:handle_order_process_failure, :some_line_items_are_out_of_stock, 'My error message')
-        expect(subject.success?).to be false
-      end
-    end
-
-    context 'when can_cancel_pre_auth? false (pre-auth is disabled)' do
-      before do
-        allow(subject).to receive(:can_cancel_pre_auth?).and_return(false)
-      end
-
-      it 'inform user that process order failed & not calling cancel_pre_auth' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_order_process_failure for payment_number: #{payment.number} with args: [:some_line_items_are_out_of_stock, \"Out of stock\"]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_order_process_failure for payment_number: #{payment.number} in")).once
-
-        expect(user_informer).to receive(:order_process_failed).with(processing: false, reason_code: :some_line_items_are_out_of_stock, reason_message: 'Out of stock')
-        expect(subject).not_to receive(:cancel_pre_auth)
-
-        subject.send(:handle_order_process_failure, :some_line_items_are_out_of_stock, 'Out of stock')
-        expect(subject.success?).to be false
-      end
+      subject.send(:handle_order_process_failure, :some_line_items_are_out_of_stock, 'Out of stock')
+      expect(subject.success?).to be false
     end
   end
 
   describe '#handle_payment_failure' do
-    context 'when can_cancel_pre_auth (pre-auth is enabled)' do
-      before do
-        allow(subject).to receive(:can_cancel_pre_auth?).and_return(true)
-      end
+    it 'informs user of failure, enqueues cancel/release, and marks as failure' do
+      expect(user_informer).to receive(:payment_process_failed).with(
+        processing: false,
+        reason_code: :gateway_error,
+        reason_message: 'Payment gateway error'
+      )
+      expect(subject).to receive(:enqueue_void_or_cancel_payment_if_available!)
 
-      it 'inform user that payment process failed & call cancel_pre_auth' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_payment_failure for payment_number: #{payment.number} with args: [:some_line_items_are_out_of_stock, \"My error message\"]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_payment_failure for payment_number: #{payment.number} in")).once
-
-        expect(user_informer).to receive(:payment_process_failed).with(processing: true, reason_code: :some_line_items_are_out_of_stock, reason_message: 'My error message')
-        expect(subject).to receive(:cancel_pre_auth).with(:some_line_items_are_out_of_stock, 'My error message')
-
-        subject.send(:handle_payment_failure, :some_line_items_are_out_of_stock, 'My error message')
-        expect(subject.success?).to be false
-      end
-    end
-
-    context 'when can_cancel_pre_auth? false (pre-auth is disabled)' do
-      before do
-        allow(subject).to receive(:can_cancel_pre_auth?).and_return(false)
-      end
-
-      it 'inform user that payment process failed & not calling cancel_pre_auth' do
-        expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#handle_payment_failure for payment_number: #{payment.number} with args: [:some_line_items_are_out_of_stock, \"My error message\"]")).once
-        expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#handle_payment_failure for payment_number: #{payment.number} in")).once
-
-        expect(user_informer).to receive(:payment_process_failed).with(processing: false, reason_code: :some_line_items_are_out_of_stock, reason_message: 'My error message')
-        expect(subject).not_to receive(:cancel_pre_auth)
-
-        subject.send(:handle_payment_failure, :some_line_items_are_out_of_stock, 'My error message')
-        expect(subject.success?).to be false
-      end
-    end
-  end
-
-  describe '#cancel_pre_auth' do
-    it 'call void_transaction! & alert to user that payment is refunded' do
-      expect(Rails.logger).to receive(:error).with(start_with("Started Vpago::PaymentProcessor#cancel_pre_auth for payment_number: #{payment.number} with args: \[]")).once
-      expect(Rails.logger).to receive(:error).with(start_with("Completed Vpago::PaymentProcessor#cancel_pre_auth for payment_number: #{payment.number} in")).once
-
-      expect(payment).to receive(:void_transaction!)
-      expect(user_informer).to receive(:payment_is_refunded).with(processing: false, reason_code: :some_line_items_are_out_of_stock, reason_message: 'My error message')
-
-      subject.send(:cancel_pre_auth, :some_line_items_are_out_of_stock, 'My error message')
-    end
-  end
-
-  describe '#can_cancel_pre_auth?' do
-    context 'when payment is pending (which mean pre-auth enabled & money is authorized)' do
-      let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order, state: :pending) }
-
-      it 'return true' do
-        expect(payment.pending?).to be true
-        expect(subject.send(:can_cancel_pre_auth?)).to be true
-      end
-    end
-
-    context 'pre-auth is enabled' do
-      let(:payment_method) { create(:payway_v2_gateway, enable_pre_auth: true, preferred_public_key: 'THIS IS PRE-AUTH KEY') }
-      let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order, state: :checkout, payment_method: payment_method) }
-
-      it 'return true' do
-        expect(payment.pending?).to be false
-        expect(payment.payment_method.enable_pre_auth?).to be true
-        expect(subject.send(:can_cancel_pre_auth?)).to be true
-      end
-    end
-
-    context 'pre-auth is disable and payment is not authroized' do
-      let(:payment_method) { create(:payway_v2_gateway, enable_pre_auth: false) }
-      let(:payment) { create(:payway_v2_payment, number: 'PJ0MYD2Y', order: order, state: :checkout, payment_method: payment_method) }
-
-      it 'return false' do
-        expect(payment.pending?).to be false
-        expect(payment.payment_method.enable_pre_auth?).to be false
-        expect(subject.send(:can_cancel_pre_auth?)).to be false
-      end
-    end
-  end
-
-  describe '#extract_completer_failure_reason_code' do
-    context 'when some items are out of stock' do      
-      before do
-        allow_any_instance_of(Spree::LineItem).to receive(:sufficient_stock?).and_return(false)
-      end
-
-      it 'return reason code :some_line_items_are_out_of_stock' do
-        completer = Spree::Checkout::Complete.new.call(order: order)
-        expect(subject.send(:extract_completer_failure_reason_code, completer.error)).to eq :some_line_items_are_out_of_stock
-      end
-    end
-
-    context 'when some items are discontinued' do      
-      before do
-        allow_any_instance_of(Spree::Variant).to receive(:discontinued?).and_return(true)
-      end
-
-      it 'return reason code :some_line_items_are_out_of_stock' do
-        completer = Spree::Checkout::Complete.new.call(order: order)
-        expect(subject.send(:extract_completer_failure_reason_code, completer.error)).to eq :some_variants_are_discontinued
-      end
-    end
-
-    context 'when error message is neither of above cases' do
-      it 'return reason code :some_line_items_are_out_of_stock' do
-        expect(subject.send(:extract_completer_failure_reason_code, { :base => nil })).to eq :unable_to_complete_order
-        expect(subject.send(:extract_completer_failure_reason_code, '')).to eq :unable_to_complete_order
-        expect(subject.send(:extract_completer_failure_reason_code, {})).to eq :unable_to_complete_order
-        expect(subject.send(:extract_completer_failure_reason_code, nil)).to eq :unable_to_complete_order
-      end
+      subject.send(:handle_payment_failure, :gateway_error, 'Payment gateway error')
+      expect(subject.success?).to be false
     end
   end
 end


### PR DESCRIPTION
> once #309 is merged, i will rebase so it has 1 commit.

## Why do this?

Original `process!` & `capture!` calls `started_processing!` to move state from `[:checkout, :pending, :completed, :processing]` → `:processing`. Then it starts processing with the bank.

Anyway, when the processing fails (eg. connection issue), it calls `payment.failure` which transitions the payment state to `:failed`.

So even our sidekiq job tries to retry, which trigger `started_processing!` again, it will block the transition  (it doesn't allow state from `:failed` to `:processing`), so we need to reset the state back to `:checkout` .

## Solution
So in this PR, we add event state machine event call `reset_for_retry!` to reset the status. This new state machine event also allows us to track the state change of payment (it is better than updating the column state directly)

Finally, with this changes, it allows `process!` or `capture!` to be retried by Sidekiq or by admin via /fire after connection errors or other transient gateway failures.