### PR TITLE
Close #323 Implemente logging instrumentation Payway Queue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_vpago (2.1.9)
+    spree_vpago (2.2.1)
       faraday
       google-cloud-firestore
       spree_api (>= 4.5)
@@ -188,7 +188,7 @@ GEM
     faraday-http-cache (2.5.0)
       faraday (>= 0.8)
     faraday-net_http (3.0.2)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffaker (2.21.0)
     ffi (1.15.5)

--- a/app/controllers/spree/vpago_payments_controller.rb
+++ b/app/controllers/spree/vpago_payments_controller.rb
@@ -44,14 +44,15 @@ module Spree
       return render_not_found unless @payment.present?
 
       unless @payment.order.paid?
-        Vpago::PaymentProcessorJob.perform_later(
-          payment_number: @payment.number
-        )
+        enqueued_at = Time.now.to_f
+        log_enqueue_start(@payment, enqueued_at, return_params)
+
+        Vpago::PaymentProcessorJob.perform_later(payment_number: @payment.number, enqueued_at: enqueued_at)
       end
 
       render json: { status: :ok }, status: :ok
     rescue StandardError => e
-      Rails.logger.error("Failed to enqueued payment processor job: #{params} #{e.message}")
+      log_enqueue_error(e)
       render json: { status: :internal_server_error, message: 'Failed to enqueue payment processor job' }, status: :internal_server_error
     end
 
@@ -62,13 +63,20 @@ module Spree
       @payment = Spree::Payment.find_by(number: params.dig(:data, :external_ref_id))
       return render_not_found unless @payment
 
-      Vpago::PaymentProcessorJob.perform_later(payment_number: @payment.number) unless @payment.order.paid?
+      unless @payment.order.paid?
+        enqueued_at = Time.now.to_f
+        log_enqueue_start(@payment, enqueued_at)
+
+        Vpago::PaymentProcessorJob.perform_later(payment_number: @payment.number, enqueued_at: enqueued_at)
+      end
 
       render json: { status: { code: '000001', message: 'success' }, data: nil }, status: :ok
     rescue StandardError => e
-      Rails.logger.error("Payment error: #{e.message}")
+      log_enqueue_error(e)
       render json: { status: :internal_server_error, message: 'Failed to enqueue payment processor job' }, status: :internal_server_error
     end
+
+    private
 
     def sanitize_return_params
       sanitized_params = params.permit!.to_h
@@ -91,6 +99,42 @@ module Spree
         format.html { render file: Rails.public_path.join('422.html'), status: :not_found, layout: false }
         format.json { render json: { status: :unauthorized }, status: :unauthorized }
       end
+    end
+
+    def log_enqueue_start(payment, enqueued_at, return_params = {})
+      VpagoLogger.log(
+        event: 'vpago.payment_processor_job.enqueue',
+        data: {
+          payment_number: payment.number,
+          order_number: payment.order&.number,
+          request_id: request.request_id,
+          payment_method_type: payment.payment_method&.type,
+          payment_method_name: payment.payment_method&.name,
+          gateway: detect_payway_gateway_version(payment.payment_method),
+          tran_id: (return_params[:tran_id] || return_params['tran_id']),
+          enqueued_at: enqueued_at
+        }
+      )
+    end
+
+    def log_enqueue_error(error)
+      VpagoLogger.error(
+        event: 'vpago.payment_processor_job.enqueue.error',
+        data: {
+          request_id: request.request_id,
+          payment_number: @payment&.number,
+          error_class: error.class.name,
+          error_message: error.message
+        }
+      )
+    end
+
+    def detect_payway_gateway_version(payment_method)
+      return nil unless payment_method
+      return 'payway_v2' if payment_method.type_payway_v2?
+      return 'payway_v1' if payment_method.type_payway?
+
+      nil
     end
   end
 end

--- a/app/controllers/spree/webhook/payways_controller.rb
+++ b/app/controllers/spree/webhook/payways_controller.rb
@@ -4,7 +4,7 @@ module Spree
       skip_before_action :verify_authenticity_token, only: %i[return v2_return continue v2_continue]
 
       # match via: [:get, :post]
-      # {"response"=>"{\"tran_id\":\"PE13LXT1\",\"status\":0"}"}
+      # {"response"=>"{\"tran_id\":\"PE13LXT1\",\"status\":0}"}
       def v2_return
         handler_service = v2_request_updater_service
 
@@ -48,7 +48,7 @@ module Spree
         request_updater.call
 
         order = payment.order
-        order = order.reload
+        order.reload
 
         if order.paid? || payment.pending?
           render plain: :success

--- a/app/jobs/vpago/payment_processor_job.rb
+++ b/app/jobs/vpago/payment_processor_job.rb
@@ -1,11 +1,71 @@
 # Put :payment_processing at a higher priority in your project: config/sidekiq.yml
+require 'vpago/timing_helper'
+
 module Vpago
   class PaymentProcessorJob < ::ApplicationUniqueJob
     queue_as :payment_processing
 
     def perform(options)
+      started_at = Vpago::TimingHelper.current_time
+      enqueued_at = options[:enqueued_at]
+      queue_wait_ms = calculate_queue_wait_ms(enqueued_at)
+
+      log_job_start(options[:payment_number], queue_wait_ms)
+
       payment = Spree::Payment.find_by!(number: options[:payment_number])
       Vpago::PaymentProcessor.new(payment: payment).call
+
+      log_job_finish(options[:payment_number], queue_wait_ms, started_at)
+    rescue StandardError => e
+      log_job_error(options[:payment_number], queue_wait_ms, started_at, e)
+      raise
+    end
+
+    private
+
+    def calculate_queue_wait_ms(enqueued_at)
+      return nil unless enqueued_at
+
+      ((Time.now.to_f - enqueued_at.to_f) * 1000.0).round(1)
+    end
+
+    def log_job_start(payment_number, queue_wait_ms)
+      VpagoLogger.log(
+        event: 'vpago.payment_processor_job.start',
+        data: {
+          payment_number: payment_number,
+          queue: self.class.queue_name,
+          queue_wait_ms: queue_wait_ms
+        }
+      )
+    end
+
+    def log_job_finish(payment_number, queue_wait_ms, started_at)
+      runtime_ms = Vpago::TimingHelper.elapsed_ms(started_at)
+      VpagoLogger.log(
+        event: 'vpago.payment_processor_job.finish',
+        data: {
+          payment_number: payment_number,
+          queue: self.class.queue_name,
+          queue_wait_ms: queue_wait_ms,
+          runtime_ms: runtime_ms
+        }
+      )
+    end
+
+    def log_job_error(payment_number, queue_wait_ms, started_at, error)
+      runtime_ms = Vpago::TimingHelper.elapsed_ms(started_at)
+      VpagoLogger.error(
+        event: 'vpago.payment_processor_job.error',
+        data: {
+          payment_number: payment_number,
+          queue: self.class.queue_name,
+          queue_wait_ms: queue_wait_ms,
+          runtime_ms: runtime_ms,
+          error_class: error.class.name,
+          error_message: error.message
+        }
+      )
     end
   end
 end

--- a/app/lib/vpago/timing_helper.rb
+++ b/app/lib/vpago/timing_helper.rb
@@ -1,0 +1,28 @@
+module Vpago
+  module TimingHelper
+    # Gets the current monotonic timestamp.
+    #
+    # @return [Float] current timestamp from Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    def self.current_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Measures elapsed time in milliseconds from a given start timestamp.
+    #
+    # @param started_at [Float] timestamp from Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    # @return [Float] elapsed time in milliseconds, rounded to 1 decimal place
+    def self.elapsed_ms(started_at)
+      ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000.0).round(1)
+    end
+
+    # Yields to a block and measures its execution time in milliseconds.
+    #
+    # @yield the block to measure
+    # @return [Float] elapsed time in milliseconds, rounded to 1 decimal place
+    def self.measure_ms
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      elapsed_ms(started_at)
+    end
+  end
+end

--- a/lib/spree_vpago/version.rb
+++ b/lib/spree_vpago/version.rb
@@ -1,7 +1,7 @@
 module SpreeVpago
   module_function
 
-  VERSION = '2.1.9'.freeze
+  VERSION = '2.2.1'.freeze
 
   def version
     Gem::Version.new VERSION

--- a/lib/vpago/payway_v2/transaction_status.rb
+++ b/lib/vpago/payway_v2/transaction_status.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'vpago/timing_helper'
 
 module Vpago
   module PaywayV2
@@ -35,6 +36,8 @@ module Vpago
       end
 
       def check_remote_status
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
         conn = Faraday::Connection.new do |faraday|
           faraday.request :url_encoded
         end
@@ -46,7 +49,33 @@ module Vpago
           hash: checker_hmac
         }
 
-        conn.post(check_transaction_url, data)
+        response = conn.post(check_transaction_url, data)
+
+        runtime_ms = Vpago::TimingHelper.elapsed_ms(started_at)
+        Rails.logger.info(
+          {
+            event: 'vpago.payway.check_transaction',
+            version: 'v2',
+            payment_number: transaction_id,
+            http_status: response.status,
+            runtime_ms: runtime_ms
+          }
+        )
+
+        response
+      rescue StandardError => e
+        runtime_ms = Vpago::TimingHelper.elapsed_ms(started_at)
+        Rails.logger.error(
+          {
+            event: 'vpago.payway.check_transaction.error',
+            version: 'v2',
+            payment_number: transaction_id,
+            runtime_ms: runtime_ms,
+            error_class: e.class.name,
+            error_message: e.message
+          }
+        )
+        raise
       end
 
       def payout_total

--- a/lib/vpago_logger.rb
+++ b/lib/vpago_logger.rb
@@ -1,0 +1,21 @@
+module VpagoLogger
+  def self.log(event:, data: nil)
+    message = { event: event }
+    message.merge!(data) if data
+
+    Rails.logger.info(message.to_json)
+    message
+  rescue StandardError
+    message
+  end
+
+  def self.error(event:, data: nil)
+    message = { event: event }
+    message.merge!(data) if data
+
+    Rails.logger.error(message.to_json)
+    message
+  rescue StandardError
+    message
+  end
+end

--- a/spec/controllers/spree/vpago_payments_controller_spec.rb
+++ b/spec/controllers/spree/vpago_payments_controller_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe Spree::VpagoPaymentsController, type: :request do
       it 'find payment with return params & enqueues the PaymentProcessorJob' do
         expect {
           post '/vpago_payments/process_payment', params: params
-        }.to have_enqueued_job(Vpago::PaymentProcessorJob).with(payment_number: payment.number)
+        }.to have_enqueued_job(Vpago::PaymentProcessorJob).with(
+          hash_including(payment_number: payment.number, enqueued_at: a_kind_of(Float))
+        )
       end
     end
   end

--- a/spec/lib/vpago_logger_spec.rb
+++ b/spec/lib/vpago_logger_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe VpagoLogger do
+  let(:test_event) { 'vpago.test.event' }
+  let(:test_data) { { payment_number: 'P123', order_number: 'O456' } }
+
+  describe '.log' do
+    it 'logs info message with event and data' do
+      expect(Rails.logger).to receive(:info) do |json|
+        expect(JSON.parse(json)).to eq(
+          'event' => test_event,
+          'payment_number' => 'P123',
+          'order_number' => 'O456'
+        )
+      end
+
+      expect(VpagoLogger.log(event: test_event, data: test_data)).to eq(
+        event: test_event,
+        payment_number: 'P123',
+        order_number: 'O456'
+      )
+    end
+
+    it 'logs info message with only event when no data provided' do
+      expect(Rails.logger).to receive(:info) do |json|
+        expect(JSON.parse(json)).to eq('event' => test_event)
+      end
+
+      expect(VpagoLogger.log(event: test_event)).to eq(event: test_event)
+    end
+
+    it 'logs info message with nil data when data is nil' do
+      expect(Rails.logger).to receive(:info) do |json|
+        expect(JSON.parse(json)).to eq('event' => test_event)
+      end
+
+      expect(VpagoLogger.log(event: test_event, data: nil)).to eq(event: test_event)
+    end
+  end
+
+  describe '.error' do
+    it 'logs error message with event and data' do
+      expect(Rails.logger).to receive(:error) do |json|
+        expect(JSON.parse(json)).to eq(
+          'event' => test_event,
+          'payment_number' => 'P123',
+          'order_number' => 'O456'
+        )
+      end
+
+      expect(VpagoLogger.error(event: test_event, data: test_data)).to eq(
+        event: test_event,
+        payment_number: 'P123',
+        order_number: 'O456'
+      )
+    end
+
+    it 'logs error message with only event when no data provided' do
+      expect(Rails.logger).to receive(:error) do |json|
+        expect(JSON.parse(json)).to eq('event' => test_event)
+      end
+
+      expect(VpagoLogger.error(event: test_event)).to eq(event: test_event)
+    end
+
+    it 'logs error message with nil data when data is nil' do
+      expect(Rails.logger).to receive(:error) do |json|
+        expect(JSON.parse(json)).to eq('event' => test_event)
+      end
+
+      expect(VpagoLogger.error(event: test_event, data: nil)).to eq(event: test_event)
+    end
+  end
+
+  describe 'integration test' do
+    it 'produces valid JSON output' do
+      expect {
+        VpagoLogger.log(event: 'vpago.payment.test', data: { key: 'value' })
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
### WHY Process.clock_gettime(Process::CLOCK_MONOTONIC)
- actually usually faster than Time.current, especially if you skip timezone conversion.
<img width="794" height="463" alt="Screenshot 2026-02-05 at 8 35 03 in the evening" src="https://github.com/user-attachments/assets/c65605ed-fd1c-4412-b8f6-6361dfff509a" />

### End-to-end timeline for payment P0IWOZ2F
- Enqueue (vpago.payment_processor_job.enqueue) at 1770285051.05206
- Job starts (vpago.payment_processor_job.start) after 188 ms queue wait
- Payway transaction check (vpago.payway.check_transaction) takes 320 ms
- Job finishes (vpago.payment_processor_job.finish) after 3.7 seconds total runtime

```json
"message":"{\"event\":\"vpago.payment_processor_job.enqueue\",\"payment_number\":\"PBGYAG64\",\"order_number\":\"R017955301\",\"request_id\":\"425ce60d-d7d6-3d01-5701-e1889dab7e76\",\"payment_method_type\":\"Spree::Gateway::PaywayV2\",\"payment_method_name\":\"ABA PAYs\",\"gateway\":\"payway_v2\",\"tran_id\":null,\"enqueued_at\":1770302870.163058}"}
```
```json
"message":"{\"event\":\"vpago.payment_processor_job.start\",\"payment_number\":\"PBGYAG64\",\"queue\":\"payment_processing\",\"queue_wait_ms\":32.6}"}
```

```json
"message":"{\"event\":\"vpago.payment_processor_job.finish\",\"payment_number\":\"PBGYAG64\",\"queue\":\"payment_processing\",\"queue_wait_ms\":218.7,\"runtime_ms\":6417.3}"}
```

```json
{"event":"vpago.payway.check_transaction","version":"v2","payment_number":"P2ED9CJQ","http_status":200,"runtime_ms":614.0}}
```