### PR TITLE
Close #336 add review mode for payway_v2

### DIFF
--- a/app/assets/javascripts/vpago/vpago_payments/request_process_payment.js
+++ b/app/assets/javascripts/vpago/vpago_payments/request_process_payment.js
@@ -18,7 +18,7 @@ async function requestProcessPayment({
             .querySelector('meta[name="csrf-token"]')
             .getAttribute("content"),
         },
-        body: JSON.stringify(params),
+        body: JSON.stringify({ ...params, internal_client: "true" }),
       });
 
       if (!response.ok) {

--- a/app/controllers/spree/vpago_payments_controller.rb
+++ b/app/controllers/spree/vpago_payments_controller.rb
@@ -81,6 +81,13 @@ module Spree
 
       Rails.logger.info("[Vpago][#{@payment.number}] Payment found: #{@payment&.number}, order: #{@payment&.order&.number}")
 
+      # for ABA reviewing mode, we can disable pushback from bank, and only process it from our app UI instead.
+      # This will give ABA team to know that we don't rely on just pushback and have fallback to process payment.
+      if @payment.payment_method.type_payway_v2? && @payment.payment_method.reviewing_mode? && request_from_external_server?
+        Rails.logger.info("[Vpago][#{@payment.number}] Received payment notification from bank in reviewing mode, skipping processing")
+        return render json: { status: :ok }, status: :ok
+      end
+
       unless @payment.order.paid?
         Rails.logger.info("[Vpago][#{@payment.number}] Enqueuing payment processor job for payment #{@payment.number}")
         Vpago::PaymentProcessorJob.perform_later(
@@ -132,6 +139,10 @@ module Spree
         format.html { render file: Rails.public_path.join('422.html'), status: :not_found, layout: false }
         format.json { render json: { status: :unauthorized }, status: :unauthorized }
       end
+    end
+
+    def request_from_external_server?
+      params[:internal_client].blank? || params[:internal_client] == 'false'
     end
   end
 end

--- a/app/helpers/vpago/vpago_payments_helper.rb
+++ b/app/helpers/vpago/vpago_payments_helper.rb
@@ -13,6 +13,15 @@ module Vpago
       render partial: 'spree/vpago_payments/transaction_checker'
     end
 
+    # Each payment method may have their own additional processing script,
+    # so we will look for the partial based on the payment method class name.
+    #
+    # eg. processing_scripts/spree/gateway/payway_v2
+    def render_additional_processing_script(payment)
+      processing_script_partial_path = "spree/vpago_payments/processing_scripts/#{payment.payment_method.class.to_s.underscore}"
+      render partial: processing_script_partial_path if lookup_context.exists?(processing_script_partial_path, [], true)
+    end
+
     def mobile_user_agent?
       request.user_agent.to_s.downcase.match?(/android|iphone|ipad|ipod/)
     end

--- a/app/views/spree/vpago_payments/processing.html.erb
+++ b/app/views/spree/vpago_payments/processing.html.erb
@@ -3,6 +3,8 @@
 <p id="processing"></p>
 <p id="reason_message"></p>
 
+<%= render_additional_processing_script(@payment) %>
+
 <script>
   document.addEventListener("DOMContentLoaded", function() {
     let firebaseConfigs = <%= Rails.application.credentials.firebase_web_config.to_json.html_safe %>;
@@ -16,7 +18,7 @@
 
     window.listenToProcessingState({
       firebaseConfigs: firebaseConfigs,
-      documentReferencePath: "<%= payment.user_informer.document_reference_path %>",
+      documentReferencePath: "<%= @payment.user_informer.document_reference_path %>",
       onPaymentIsProcessing: function (orderState, paymentState, processing, reasonCode, reasonMessage) {
         document.getElementById("status").innerText = "Payment is processing";
         document.getElementById("reason_code").innerText = reasonCode;

--- a/app/views/spree/vpago_payments/processing_scripts/spree/gateway/_payway_v2.html.erb
+++ b/app/views/spree/vpago_payments/processing_scripts/spree/gateway/_payway_v2.html.erb
@@ -1,0 +1,27 @@
+<% if @payment.payment_method.reviewing_mode? %>
+  <script>
+    // This block in /processing is purely JUST for review/audit purposes (ABA requirement).
+    // It checks the bank transaction status periodically without actually
+    // triggering payment processing again. By the time the user lands
+    // on this page, the transaction is normally complete or failed.
+    //
+    // What it does:
+    // 1. Logs or updates the UI with transaction status for review.
+    // 2. Provides reassurance that the bank transaction was confirmed.
+    // 3. Optionally, could allow a manual retry button if needed.
+    //
+    // What it does NOT do:
+    // - It does NOT call requestProcessPayment again (payment job is
+    //   already unique and idempotent elsewhere).
+    // - It does NOT retry processing unnecessarily.
+    document.addEventListener("DOMContentLoaded", function() {
+      window.checkTransactionPeriodically({
+        checkTransactionUrl: "<%= raw @payment.check_transaction_url %>",
+        onFailure: () => console.log("[Vpago] ABA Review Mode: bank transaction failed ❌"),
+        onSuccess: () => console.log("[Vpago] ABA Review Mode: bank transaction confirmed ✅"),
+        maxDurationMs: 5 * 60 * 1000, // 5 minutes,
+        pollIntervalMs: 5000, // 5 seconds
+      })
+    });
+  </script>
+<% end %>

--- a/spec/controllers/spree/vpago_payments_controller_spec.rb
+++ b/spec/controllers/spree/vpago_payments_controller_spec.rb
@@ -15,5 +15,42 @@ RSpec.describe Spree::VpagoPaymentsController, type: :request do
         }.to have_enqueued_job(Vpago::PaymentProcessorJob).with(payment_number: payment.number)
       end
     end
+
+    context 'when in reviewing mode with payway_v2' do
+      let(:params) { { tran_id: payment.number, return_params: checkout.return_params } }
+
+      context 'and request is from external server (bank)' do
+        before do
+          payment.payment_method.update!(preferred_reviewing_mode: true)
+        end
+
+        it 'does not enqueue PaymentProcessorJob' do
+          expect {
+            post '/vpago_payments/process_payment', params: params
+          }.not_to have_enqueued_job(Vpago::PaymentProcessorJob)
+        end
+
+        it 'returns status ok' do
+          post '/vpago_payments/process_payment', params: params
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)).to eq({ 'status' => 'ok' })
+        end
+      end
+
+      context 'and request is from internal client' do
+        let(:params_with_internal_client) { { tran_id: payment.number, return_params: checkout.return_params, internal_client: 'true' } }
+
+        before do
+          payment.payment_method.update!(preferred_reviewing_mode: true)
+        end
+
+        it 'enqueues PaymentProcessorJob' do
+          expect {
+            post '/vpago_payments/process_payment', params: params_with_internal_client
+          }.to have_enqueued_job(Vpago::PaymentProcessorJob).with(payment_number: payment.number)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The ABA review team wants us to make sure that we don't rely on ABA pushback. So, for proving and getting approved faster (even for future apps), this PR add review_mode option, which will behave as follows:
1. On /processing page, review mode will poll check the transaction every 5s for 5 minutes 
2. On /process (ABA pushback), we disable the enqueue process job to allow our website to trigger the process job instead of ABA