### PR TITLE
Close #342 improve aba_khqr_deeplink implementations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_vpago (2.2.2.pre.pre29)
+    spree_vpago (2.3.1)
       faraday
       google-cloud-firestore
       spree_api (>= 4.5)

--- a/app/controllers/spree/admin/payment_methods_controller_decorator.rb
+++ b/app/controllers/spree/admin/payment_methods_controller_decorator.rb
@@ -6,10 +6,12 @@ module Spree
 
         if params[:tab] == 'vendors'
           scope.where.not(vendor_id: nil)
+               .includes(:vendor)
         elsif params[:tab] == 'tenants'
           scope.joins(:vendor)
                .where.not(vendor_id: nil)
                .where.not(spree_vendors: { tenant_id: nil })
+               .includes(vendor: :tenant)
         else
           scope.where(vendor_id: nil)
         end

--- a/app/models/spree/gateway/payway_v2.rb
+++ b/app/models/spree/gateway/payway_v2.rb
@@ -6,7 +6,7 @@ module Spree
     preference :host, :string
     preference :api_key, :string
     preference :merchant_id, :string
-    preference :payment_option, :string
+    preference :payment_option, :string, default: 'abapay_khqr_deeplink'
     preference :transaction_fee_fix, :string
     preference :transaction_fee_percentage, :string
     preference :public_key, :text

--- a/app/overrides/spree/admin/payment_methods/index/tenant_body.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/index/tenant_body.html.erb.deface
@@ -1,5 +1,11 @@
 <!-- insert_before "[data-hook='admin_payment_methods_index_row_actions']" -->
 
 <% if params[:tab] == 'tenants' %>
-  <td class="text-center"><%= method.vendor&.name || 'N/A' %></td>
+  <td class="text-center">
+    <% if method.vendor&.tenant&.present? %>
+      <%= link_to method.vendor.tenant.name, edit_admin_tenant_path(method.vendor.tenant), target: "_blank" %>
+    <% else %>
+      N/A
+    <% end %>
+  </td>
 <% end %>

--- a/app/overrides/spree/admin/payment_methods/index/vendor_body.html.erb.deface
+++ b/app/overrides/spree/admin/payment_methods/index/vendor_body.html.erb.deface
@@ -1,5 +1,11 @@
 <!-- insert_before "[data-hook='admin_payment_methods_index_row_actions']" -->
 
 <% if params[:tab] == 'vendors' %>
-  <td class="text-center"><%= method.vendor&.name || 'N/A' %></td>
+  <td class="text-center">
+    <% if method.vendor&.present? %>
+      <%= link_to method.vendor.name, edit_admin_vendor_path(method.vendor), target: "_blank" %>
+    <% else %>
+      N/A
+    <% end %>
+  </td>
 <% end %>

--- a/app/views/spree/vpago_payments/forms/spree/gateway/_payway_v2.html.erb
+++ b/app/views/spree/vpago_payments/forms/spree/gateway/_payway_v2.html.erb
@@ -13,11 +13,14 @@
 </form>
 
 <script>
-  const isMobile = <%= mobile_user_agent? %>;
-
   const abapayKhqrDeeplink = <%= @payment.payment_method.abapay_khqr_deeplink? %>;
-  const shouldOpenAbaPayDeeplink = isMobile && <%= @payment.payment_method.open_abapay_deeplink? %>;
-  const shouldOpenCheckoutUrl = <%= @payment.payment_method.open_checkout_url? %>;
+  const shouldOpenAbaPayDeeplink = <%= mobile_user_agent? && @payment.payment_method.open_abapay_deeplink? %>;
+
+  // If the device is not mobile, deeplinks won't work anyway,
+  // so we always open the checkout URL (KHQR page) for desktop users.
+  // 
+  // On mobile, only open the checkout URL if explicitly enabled.
+  const shouldOpenCheckoutUrl = <%= !mobile_user_agent? || @payment.payment_method.open_checkout_url? %>;
 
   function showRedirectContainer(buttonLabel = null, onClick = null) {
     const loadingContainer = document.getElementById('vpago_loading_container');
@@ -62,12 +65,24 @@
         return;
       }
 
+      let deeplinkTriggered = false;
+
       if (data.abapay_deeplink && shouldOpenAbaPayDeeplink) {
         window.location.href = data.abapay_deeplink;
+        deeplinkTriggered = true;
       }
 
       if (data.checkout_qr_url && shouldOpenCheckoutUrl) {
-        window.location.href = data.checkout_qr_url;
+        // If a deeplink is triggered, add a short delay before navigating to the checkout URL.
+        // Without this delay, some platforms (especially Android) may ignore or cancel the deeplink
+        // because a second navigation happens too quickly.
+        if (deeplinkTriggered){
+          setTimeout(() => {
+            window.location.href = data.checkout_qr_url;
+          }, 300);
+        } else {
+          window.location.href = data.checkout_qr_url;
+        }
       }
 
       var shouldShowRedirectContainer = !shouldOpenCheckoutUrl && shouldOpenAbaPayDeeplink;

--- a/lib/spree_vpago/version.rb
+++ b/lib/spree_vpago/version.rb
@@ -1,7 +1,7 @@
 module SpreeVpago
   module_function
 
-  VERSION = '2.2.2-pre29'.freeze
+  VERSION = '2.3.1'.freeze
 
   def version
     Gem::Version.new VERSION


### PR DESCRIPTION
After releasing, I got a few feedbacks:
1. On desktop, as ABA Pays can't open the deeplink, we show blank page previously, now we fallback to show KHQR instead.

    Before:
    <img src="https://github.com/user-attachments/assets/0dd1bbf7-8895-49ce-8e50-1563f3ee967a" width="350px" />
    
    Now:
    <img src="https://github.com/user-attachments/assets/5113d935-1033-46ff-a94e-c80819f2a4d4" width="350px" />

3. On payment methods, there is no link to vendor/tenant, added now for easier managing.
    <img src="https://github.com/user-attachments/assets/4e834b9f-d58c-495e-9e28-c8a6e77f7849" width="350px" />

