### PR TITLE
Close #344 hotfix payment method skip filtering for vendor/tenant

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spree_vpago (2.3.1)
+    spree_vpago (2.3.2)
       faraday
       google-cloud-firestore
       spree_api (>= 4.5)

--- a/app/models/vpago/order_decorator.rb
+++ b/app/models/vpago/order_decorator.rb
@@ -1,11 +1,12 @@
 module Vpago
   module OrderDecorator
     extend Spree::DisplayMoney
+
     money_methods :order_adjustment_total, :shipping_discount
 
     def self.prepended(base)
       base.has_many :payouts, class_name: 'Spree::Payout', through: :payments
-      base.has_many :vendor_payment_methods, -> { unscope(:order).distinct },
+      base.has_many :vendor_payment_methods, -> { where(spree_payment_methods: { deleted_at: nil }).reorder(nil).distinct },
                     class_name: 'Spree::PaymentMethod',
                     through: :line_items
 
@@ -51,19 +52,29 @@ module Vpago
 
     # override
     def available_payment_methods(store = nil)
-      payment_methods = if respond_to?(:tenant) && tenant.present?
-                          tenant_payment_methods
-                        elsif vendor_payment_methods.any?
-                          vendor_payment_methods
-                        else
-                          collect_payment_methods(store)
-                        end
+      @available_payment_methods ||= begin
+        payment_methods = if respond_to?(:tenant) && tenant.present?
+                            tenant_payment_methods
+                          elsif vendor_payment_methods.any?
+                            vendor_payment_methods
+                          else
+                            store ||= self.store
+                            store.payment_methods
+                          end
 
-      @available_payment_methods ||= if required_payway_payout?
-                                       payment_methods.select(&:support_payout?)
-                                     else
-                                       payment_methods
-                                     end
+        payment_methods = if early_adopter?
+                            payment_methods.available_on_frontend_for_early_adopter.select { |pm| pm.available_for_order?(self) }
+                          else
+                            payment_methods.available_on_front_end.select { |pm| pm.available_for_order?(self) }
+                          end
+
+        payment_methods = payment_methods.select(&:support_payout?) if required_payway_payout?
+        payment_methods
+      end
+    end
+
+    def early_adopter?
+      user.present? && user.respond_to?(:early_adopter?) && user.early_adopter?
     end
 
     def tenant_payment_methods

--- a/lib/spree_vpago/version.rb
+++ b/lib/spree_vpago/version.rb
@@ -1,7 +1,7 @@
 module SpreeVpago
   module_function
 
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
 
   def version
     Gem::Version.new VERSION

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -118,6 +118,100 @@ RSpec.describe Spree::Order, type: :model do
       it 'return does not return any store payment methods (has no associated vendor)' do
         expect(order.available_payment_methods.pluck(:id)).not_to include(payment_method0.id)
       end
+
+      it 'removes inherited line_item ordering while keeping soft-delete filtering' do
+        deleted_vendor_payment_method = create(:payment_method, vendor: vendor1)
+        deleted_vendor_payment_method.destroy
+
+        sql = order.vendor_payment_methods.to_sql
+
+        expect(sql).not_to include('"spree_line_items"."created_at"')
+        expect(order.vendor_payment_methods).to include(payment_method1)
+        expect(order.vendor_payment_methods).not_to include(deleted_vendor_payment_method)
+      end
+
+      it 'does not raise DISTINCT + ORDER BY postgres error when loading available payment methods' do
+        expect { order.available_payment_methods.to_a }.not_to raise_error
+      end
+    end
+
+    context 'when user is early adopter' do
+      let(:store) { instance_double(Spree::Store) }
+      let(:payment_methods_scope) { double('payment_methods_scope') }
+      let(:allowed_method) { instance_double(Spree::PaymentMethod) }
+      let(:blocked_method) { instance_double(Spree::PaymentMethod) }
+
+      before do
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(order).to receive(:early_adopter?).and_return(true)
+        allow(order).to receive(:required_payway_payout?).and_return(false)
+        allow(allowed_method).to receive(:available_for_order?).with(order).and_return(true)
+        allow(blocked_method).to receive(:available_for_order?).with(order).and_return(false)
+      end
+
+      it 'uses early adopter payment method scope' do
+        expect(payment_methods_scope).to receive(:available_on_frontend_for_early_adopter).and_return([allowed_method, blocked_method])
+        expect(payment_methods_scope).not_to receive(:available_on_front_end)
+
+        expect(order.available_payment_methods).to eq([allowed_method])
+      end
+    end
+
+    context 'when user is not early adopter' do
+      let(:store) { instance_double(Spree::Store) }
+      let(:payment_methods_scope) { double('payment_methods_scope') }
+      let(:allowed_method) { instance_double(Spree::PaymentMethod) }
+      let(:blocked_method) { instance_double(Spree::PaymentMethod) }
+
+      before do
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(order).to receive(:early_adopter?).and_return(false)
+        allow(order).to receive(:required_payway_payout?).and_return(false)
+        allow(allowed_method).to receive(:available_for_order?).with(order).and_return(true)
+        allow(blocked_method).to receive(:available_for_order?).with(order).and_return(false)
+      end
+
+      it 'uses regular frontend payment method scope' do
+        expect(payment_methods_scope).to receive(:available_on_front_end).and_return([allowed_method, blocked_method])
+        expect(payment_methods_scope).not_to receive(:available_on_frontend_for_early_adopter)
+
+        expect(order.available_payment_methods).to eq([allowed_method])
+      end
+    end
+  end
+
+  describe '#early_adopter?' do
+    let(:order) { create(:order) }
+
+    it 'returns false when user is nil' do
+      allow(order).to receive(:user).and_return(nil)
+
+      expect(order.early_adopter?).to be false
+    end
+
+    it 'returns false when user does not respond to early_adopter?' do
+      user = instance_double('User', present?: true)
+      allow(user).to receive(:respond_to?).with(:early_adopter?).and_return(false)
+      allow(order).to receive(:user).and_return(user)
+
+      expect(order.early_adopter?).to be false
+    end
+
+    it 'returns true when user responds true for early_adopter?' do
+      user = instance_double('User', present?: true)
+      allow(user).to receive(:respond_to?).with(:early_adopter?).and_return(true)
+      allow(user).to receive(:early_adopter?).and_return(true)
+      allow(order).to receive(:user).and_return(user)
+
+      expect(order.early_adopter?).to be true
     end
   end
 
@@ -195,13 +289,21 @@ RSpec.describe Spree::Order, type: :model do
     let(:payment_method2) { create(:payway_v2_gateway, preferred_payment_option: 'abapay_khqr') }
     let(:payment_method3) { create(:payway_v2_gateway, preferred_payment_option: 'abapay_khqr_deeplink') }
     let(:payment_method4) { create(:acleda_payment_method) }
+    let(:store) { instance_double(Spree::Store) }
+    let(:payment_methods_scope) { double('payment_methods_scope') }
 
     let(:order) { create(:order) }
 
     context "when required_payway_payout is true" do
       before do
         allow(order).to receive(:required_payway_payout?).and_return(true)
-        allow(order).to receive(:collect_payment_methods).with(nil).and_return([payment_method1, payment_method2, payment_method3, payment_method4])
+        allow(order).to receive(:early_adopter?).and_return(false)
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(payment_methods_scope).to receive(:available_on_front_end).and_return([payment_method1, payment_method2, payment_method3, payment_method4])
       end
 
       it "returns only return payway v2 payment methods that support payout" do
@@ -216,7 +318,13 @@ RSpec.describe Spree::Order, type: :model do
     context "when required_payway_payout is false" do
       before do
         allow(order).to receive(:required_payway_payout?).and_return(false)
-        allow(order).to receive(:collect_payment_methods).with(nil).and_return([payment_method1, payment_method2, payment_method3, payment_method4])
+        allow(order).to receive(:early_adopter?).and_return(false)
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(payment_methods_scope).to receive(:available_on_front_end).and_return([payment_method1, payment_method2, payment_method3, payment_method4])
       end
       
       it "returns all payment methods" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # Configure Rails Environment
 ENV['RAILS_ENV'] = 'test'
 ENV['DEFAULT_URL_HOST'] = 'http://localhost:4000'
-ENV['PAYWAY_CHECK_TRANSACTION_PATH'] = '/api/payment-gateway/v1/payments/check-transaction'
 
 require File.expand_path('../dummy/config/environment.rb', __FILE__)
 


### PR DESCRIPTION
## Context

We identified an issue in the payment flow where some invalid, inactive, or improperly configured payment methods are still displayed to users during checkout.

As a result, users are able to:
- Select these payment methods
- Proceed through checkout
- Receive a completed booking/order status despite the payment not being properly processed (Payway v1 method)

This issue affects bus ticket bookings and results in unpaid tickets being treated as confirmed transactions.

<img width="400" alt="telegram-cloud-photo-size-5-6332075258524930292-y" src="https://github.com/user-attachments/assets/41038b45-b305-4d9f-b0d6-e83969bdd023" />

## Solution
This PR adds all missing filtering and moves all filtering logics from the commissioner to here in a single place to make it easy to test.
