### PR TITLE
Close #350 improve admin backend payment link

### DIFF
--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -9,8 +9,35 @@ module Spree
         payment_method ||= Spree::PaymentMethod.find(params[:payment][:payment_method_id])
         return unless payment_method.vpago_payment?
 
-        source_params = { payment_option: payment_method.preferred_payment_option }
+        source_params = { payment_option: payment_method.try(:preferred_payment_option) }
         params[:payment][:source_attributes] = source_params
+      end
+
+      # override
+      # For vpago gateways created from the admin backend, we skip immediate processing
+      # and keep the payment in `checkout` state so the admin can open the QR checkout
+      # URL and pay on behalf of the customer. The bank webhook
+      # (process_payment -> Vpago::PaymentProcessorJob) completes the order once paid.
+      def create
+        return super unless @payment_method&.vpago_payment?
+
+        invoke_callbacks(:create, :before)
+
+        @payment = @order.payments.build(object_params)
+
+        if @payment.save
+          invoke_callbacks(:create, :after)
+          flash[:success] = flash_message_for(@payment, :successfully_created)
+          redirect_to spree.admin_order_payments_path(@order)
+        else
+          invoke_callbacks(:create, :fails)
+          flash[:error] = Spree.t(:payment_could_not_be_created)
+          render :new, status: :unprocessable_entity
+        end
+      rescue Spree::Core::GatewayError => e
+        invoke_callbacks(:create, :fails)
+        flash[:error] = e.message.to_s
+        redirect_to spree.new_admin_order_payment_path(@order)
       end
     end
   end

--- a/app/overrides/spree/admin/payments/_form/admin_payment_form_fields.html.erb.deface
+++ b/app/overrides/spree/admin/payments/_form/admin_payment_form_fields.html.erb.deface
@@ -1,0 +1,36 @@
+<!-- replace "[data-hook='admin_payment_form_fields']" -->
+
+<div data-hook="admin_payment_form_fields">
+  <div class="form-group">
+    <%= f.label :amount, Spree.t(:amount) %>
+    <%= f.text_field :amount, value: @order.display_outstanding_balance.money, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <strong><%= Spree.t(:payment_method) %></strong>
+    <% @payment_methods.each do |method| %>
+      <div class="radio" data-id="<%= Spree.t(method.name, scope: :payment_methods, default: method.name).parameterize %>">
+        <label data-hook="payment_method_field">
+          <%= radio_button_tag 'payment[payment_method_id]', method.id, method == @payment_method, { class: "payment_methods_radios" } %>
+          <%= Spree.t(method.name, scope: :payment_methods, default: method.name) %>
+        </label>
+      </div>
+    <% end %>
+
+    <div class="payment-method-settings">
+      <% @payment_methods.each do |method| %>
+        <div class="payment-methods my-3" id="payment_method_<%= method.id %>">
+          <% if method.source_required? %>
+            <% partial_path = "spree/admin/payments/source_forms/#{method.method_type}" %>
+            <% if lookup_context.exists?(partial_path, [], true) %>
+              <%= render partial: partial_path,
+                         locals: {
+                           payment_method: method,
+                           previous_cards: method.reusable_sources(@order)
+                         } %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
### Problem

When admin creates a QR-based payment (ABA KHQR / Vattanac) from the backend, Spree immediately tries to process it, causing it to fail since the admin hasn't paid yet.

### Solution
Override the admin payments `create` action for all vpago gateways to skip immediate processing. The payment stays in `checkout` state, giving the admin time to open the QR checkout URL and pay. The bank webhook (`Vpago::PaymentProcessorJob`) completes the order once payment is confirmed.

### Changes

- Overide `create` in the admin payments controller decorator to skip `@order.next` and `payment.process!` for any `vpago_payment?` gateway, with a `GatewayError` rescue to show proper error messages

- Add deface override for the admin payment form to:
  - Guard source form partial rendering with `lookup_context.exists?` so new vpago gateways don't require an empty partial file

- Redirect to the payments list after creation so admin can immediately see the Open Checkout action


### Demo

https://github.com/user-attachments/assets/20362ebd-e15e-4455-8735-c50fb38479ba

