### PR TITLE
Close #354 allow stuck payment to be reprocessed

### DIFF
--- a/app/controllers/spree/admin/payments_controller_decorator.rb
+++ b/app/controllers/spree/admin/payments_controller_decorator.rb
@@ -39,6 +39,25 @@ module Spree
         flash[:error] = e.message.to_s
         redirect_to spree.new_admin_order_payment_path(@order)
       end
+
+      # override
+      # Before the normal `process!` re-runs the gateway, reset a stuck vpago
+      # payment back to `checkout`. Admin reprocess only — the automatic webhook
+      # path is untouched (it auto-resets `failed` alone).
+      def fire
+        reset_stuck_payment_for_reprocess!
+        super
+      end
+
+      private
+
+      def reset_stuck_payment_for_reprocess!
+        return unless params[:e] == 'process'
+        return unless @payment&.payment_method&.vpago_payment?
+        return unless @payment.can_reset_for_retry?
+
+        @payment.reset_for_retry!
+      end
     end
   end
 end

--- a/app/models/vpago/payment_decorator.rb
+++ b/app/models/vpago/payment_decorator.rb
@@ -27,9 +27,11 @@ module Vpago
                     :process_payment_url,
                     to: :url_constructor
 
-      # Add state machine event for payment retry
+      # State machine event for payment retry / admin reprocess.
+      # `failed` is auto-reset by process!/capture! below (Sidekiq retry);
+      # void/invalid/processing are reset only by the admin reprocess action.
       base.state_machine.event :reset_for_retry do
-        transition from: %i[failed], to: :checkout
+        transition from: %i[failed void invalid processing], to: :checkout
       end
     end
 

--- a/app/overrides/spree/admin/payments/_list/actions.html.erb.deface
+++ b/app/overrides/spree/admin/payments/_list/actions.html.erb.deface
@@ -7,7 +7,9 @@
         <% elsif action == 'open_checkout' %>
             <%= link_to_with_icon('qr-code.svg', Spree.t(action), payment.checkout_url, target: '_blank', no_text: true, class: "btn btn-light btn-sm") %>
         <% else %>
-            <%= link_to_with_icon(action + '.svg', Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: { action: action }, class: "btn btn-light btn-sm") if can?(action.to_sym, payment) %>
+            <% action_data = { action: action } %>
+            <% action_data[:confirm] = Spree.t(:reprocess_payment_confirmation, default: 'Reprocess this payment? This will re-run the gateway transaction.') if action == 'process' %>
+            <%= link_to_with_icon(action + '.svg', Spree.t(action), fire_admin_order_payment_path(@order, payment, e: action), method: :put, no_text: true, data: action_data, class: "btn btn-light btn-sm") if can?(action.to_sym, payment) %>
         <% end %>
     <% end %>
 </span>

--- a/spec/controllers/spree/admin/payments_controller_decorator_spec.rb
+++ b/spec/controllers/spree/admin/payments_controller_decorator_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+# Unit-level coverage for the reprocess reset introduced by
+# Spree::Admin::PaymentsControllerDecorator#fire. We exercise the private
+# guard directly to avoid coupling to admin authentication infrastructure,
+# while still verifying the important behaviour: which payments get reset
+# back to `checkout` before the core `fire` re-runs the gateway.
+RSpec.describe Spree::Admin::PaymentsController do
+  let(:controller) { described_class.new }
+  let(:order) { create(:order_with_line_items, state: :payment) }
+  let(:payment) { create(:payway_v2_payment, order: order) }
+
+  def stub_fire_request(event:)
+    controller.instance_variable_set(:@payment, payment)
+    allow(controller).to receive(:params).and_return(
+      ActionController::Parameters.new(e: event)
+    )
+  end
+
+  describe '#reset_stuck_payment_for_reprocess!' do
+    context 'when firing process on a vpago payment' do
+      before { stub_fire_request(event: 'process') }
+
+      %w[processing void invalid failed].each do |stuck_state|
+        it "resets a #{stuck_state} payment back to checkout" do
+          payment.update!(state: stuck_state)
+
+          expect {
+            controller.send(:reset_stuck_payment_for_reprocess!)
+          }.to change { payment.reload.state }.from(stuck_state).to('checkout')
+        end
+      end
+
+      it 'leaves a checkout payment untouched' do
+        payment.update!(state: 'checkout')
+
+        expect {
+          controller.send(:reset_stuck_payment_for_reprocess!)
+        }.not_to change { payment.reload.state }
+      end
+
+      it 'leaves a pending payment untouched' do
+        payment.update!(state: 'pending')
+
+        expect {
+          controller.send(:reset_stuck_payment_for_reprocess!)
+        }.not_to change { payment.reload.state }
+      end
+    end
+
+    context 'when firing a non-process event (e.g. void) on a stuck payment' do
+      before { stub_fire_request(event: 'void') }
+
+      it 'does not reset the payment' do
+        payment.update!(state: 'processing')
+
+        expect {
+          controller.send(:reset_stuck_payment_for_reprocess!)
+        }.not_to change { payment.reload.state }
+      end
+    end
+
+    context 'when the payment is not a vpago payment' do
+      let(:payment) { create(:payment, order: order) }
+
+      before { stub_fire_request(event: 'process') }
+
+      it 'does not reset the payment' do
+        payment.update!(state: 'failed')
+
+        expect {
+          controller.send(:reset_stuck_payment_for_reprocess!)
+        }.not_to change { payment.reload.state }
+      end
+    end
+  end
+end

--- a/spec/models/spree/payment_spec.rb
+++ b/spec/models/spree/payment_spec.rb
@@ -191,25 +191,41 @@ RSpec.describe Spree::Payment, type: :model do
     let(:payment_method) { create(:payway_v2_gateway) }
     let(:payment) { create(:payway_v2_payment, order: order, payment_method: payment_method) }
 
-    context 'when payment is in failed state' do
+    context 'when payment is in a stuck/failed state' do
       it 'transitions payment from failed to checkout' do
         payment.update!(state: 'failed')
-        
+
         expect {
           payment.reset_for_retry!
         }.to change { payment.state }.from('failed').to('checkout')
       end
-    end
 
-    context 'when payment is not in failed state' do
-      it 'does not transition from processing state' do
+      it 'transitions payment from processing to checkout' do
         payment.update!(state: 'processing')
-        
+
         expect {
           payment.reset_for_retry!
-        }.to raise_error(StateMachines::InvalidTransition)
+        }.to change { payment.state }.from('processing').to('checkout')
       end
 
+      it 'transitions payment from void to checkout' do
+        payment.update!(state: 'void')
+
+        expect {
+          payment.reset_for_retry!
+        }.to change { payment.state }.from('void').to('checkout')
+      end
+
+      it 'transitions payment from invalid to checkout' do
+        payment.update!(state: 'invalid')
+
+        expect {
+          payment.reset_for_retry!
+        }.to change { payment.state }.from('invalid').to('checkout')
+      end
+    end
+
+    context 'when payment is in a non-resettable state' do
       it 'does not transition from completed state' do
         payment.update!(state: 'completed')
         


### PR DESCRIPTION
### In this PR

Previously admin couldn't reprocess payments stuck in `processing`, `void`, or `invalid`. The **Process** button showed for these states but didn't work:

- `void` / `invalid` → firing `process` raised `StateMachines::InvalidTransition` (500).
- `processing` → the gateway call was skipped (`handle_payment_preconditions` bails while already processing), so the click silently did nothing.

This PR makes the Process button actually reprocess these stuck payments.

### Changes

- **`reset_for_retry` event**: now also transitions `void` / `invalid` / `processing` → `checkout`.
- **`Admin::PaymentsControllerDecorator#fire`**: for an admin-initiated `process` on a stuck vpago payment, resets it to `checkout` first, then runs the normal `process!` (re-checks the transaction with the bank).
- **Process button**: added a confirmation dialog since it re-runs the gateway.

### Demo

https://github.com/user-attachments/assets/df8ed9de-b4c4-4807-afc8-fb932f9859f6


