### PR TITLE
Close #356 add admin payment review page for completed orders with balance due

### DIFF
--- a/app/controllers/spree/admin/suspicious_orders_controller.rb
+++ b/app/controllers/spree/admin/suspicious_orders_controller.rb
@@ -1,0 +1,64 @@
+module Spree
+  module Admin
+    class SuspiciousOrdersController < Spree::Admin::BaseController
+      around_action :set_writing_role, only: %i[check_transaction]
+
+      def index
+        params[:q] = { completed_at_not_null: 1, payment_state_eq: 'balance_due', s: 'completed_at desc' }.dup if params[:q].blank?
+
+        @search = scope.ransack(params[:q])
+        @orders = @search.result(distinct: true)
+                         .preload(:payments, :reimbursements)
+                         .page(params[:page])
+                         .per(params[:per_page] || Spree::Backend::Config[:admin_orders_per_page])
+      end
+
+      def payments
+        @order = scope.find_by!(number: params[:id])
+        @payments = @order.payments.includes(:payment_method)
+
+        render layout: false
+      end
+
+      # Renders the result inline into this order's payments frame instead of
+      # redirecting, so the admin never leaves this list.
+      def check_transaction
+        @order = scope.find_by!(number: params[:id])
+        payment = @order.payments.find_by!(number: params[:payment_number])
+
+        @check_result = query_payment_transaction(payment)
+        @payments = @order.payments.includes(:payment_method)
+
+        render 'payments', layout: false
+      end
+
+      private
+
+      # Delegates to the gateway's own check_transaction (same method
+      # PaywayV2/Vattanac/TrueMoney already implement) - no per-gateway
+      # branching needed here.
+      def query_payment_transaction(payment)
+        method = payment.payment_method
+        return nil unless method.support_check_transaction_api?
+
+        result = method.check_transaction(payment)
+
+        # Not every gateway's checker implements error_message (e.g. Vattanac,
+        # TrueMoney) - fall back to the raw response so this doesn't blow up
+        # for gateways that only implement the minimal success?/json_response duck type.
+        message =
+          if result.success?
+            Spree.t('vpago.payments.payment_found_with_result', result: result.try(:json_response))
+          else
+            Spree.t('vpago.payments.payment_not_found_with_error', error: result.try(:error_message) || result.try(:json_response))
+          end
+
+        { success: result.success?, message: message }
+      end
+
+      def scope
+        current_store.orders.accessible_by(current_ability, :index)
+      end
+    end
+  end
+end

--- a/app/overrides/spree/admin/shared/sub_menu/_orders/suspicious_orders.html.erb.deface
+++ b/app/overrides/spree/admin/shared/sub_menu/_orders/suspicious_orders.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_bottom "[data-hook='admin_orders']" -->
+
+<%= tab :suspicious_orders, url: spree.admin_suspicious_orders_path, label: Spree.t('admin.orders.suspicious_orders') %>

--- a/app/views/spree/admin/suspicious_orders/_payments_table.html.erb
+++ b/app/views/spree/admin/suspicious_orders/_payments_table.html.erb
@@ -1,0 +1,71 @@
+<% if check_result.present? %>
+  <script>
+    show_flash('<%= check_result[:success] ? "success" : "error" %>', '<%= j check_result[:message] %>')
+  </script>
+<% end %>
+
+<table class="table mb-0">
+  <thead class="text-muted">
+    <tr>
+      <th><%= Spree::Payment.human_attribute_name(:id) %></th>
+      <th><%= Spree::Payment.human_attribute_name(:number) %></th>
+      <th><%= "#{Spree.t('date')}/#{Spree.t('time')}" %></th>
+      <th class="text-center"><%= Spree.t(:amount) %></th>
+      <th class="text-center"><%= Spree.t(:payment_method) %></th>
+      <th class="text-center"><%= Spree.t(:payment_state) %></th>
+      <th class="actions text-center"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% payments.each do |payment| %>
+      <tr>
+        <td><%= payment.id %></td>
+        <td><%= link_to payment.number, spree.admin_order_payment_path(order, payment), data: { turbo_frame: '_top' } %></td>
+        <td><%= pretty_time(payment.created_at) %></td>
+        <td class="text-center"><%= payment.display_amount %></td>
+        <td class="text-center">
+          <% payment_method = payment.payment_method %>
+          <% if can?(:update, payment_method) %>
+            <%= link_to payment_method.name, spree.edit_admin_payment_method_path(payment_method),
+                  target: '_blank', rel: 'noopener noreferrer' %>
+          <% else %>
+            <%= payment_method.name %>
+          <% end %>
+        </td>
+        <td class="text-center">
+          <span class="badge badge-pill badge-<%= payment.state %>">
+            <%= Spree.t(payment.state, scope: :payment_states, default: payment.state.capitalize) %>
+          </span>
+        </td>
+        <td class="actions">
+          <span class="d-flex justify-content-center payment-action-buttons">
+            <% if payment.payment_method.support_check_transaction_api? %>
+
+              <%= button_to spree.check_transaction_admin_suspicious_order_path(order, payment_number: payment.number),
+                    form: { data: { turbo_frame: "suspicious_order_#{order.id}_payments" }, class: 'd-inline' },
+                    class: 'btn btn-light btn-sm icon-link with-tip', title: Spree.t('vpago.payments.query_status') do %>
+                <%= svg_icon(name: 'search.svg', classes: 'icon icon-search', width: 14, height: 14) %>
+              <% end %>
+            <% end %>
+
+            <% payment.actions.each do |action| %>
+              <% if action == 'credit' %>
+                <%= link_to_with_icon('exit.svg', Spree.t(:refund), spree.new_admin_order_payment_refund_path(order, payment),
+                      no_text: true, data: { turbo_frame: '_top' }, class: 'btn btn-light btn-sm') if can?(:create, Spree::Refund) %>
+              <% elsif action == 'open_checkout' %>
+                <%= link_to_with_icon('qr-code.svg', Spree.t(action), payment.checkout_url,
+                      target: '_blank', rel: 'noopener noreferrer', no_text: true, class: 'btn btn-light btn-sm') %>
+              <% else %>
+                <% action_data = { action: action, turbo_frame: '_top' } %>
+                <% action_data[:confirm] = Spree.t(:reprocess_payment_confirmation, default: 'Reprocess this payment? This will re-run the gateway transaction.') if action == 'process' %>
+                <%= link_to_with_icon(action + '.svg', Spree.t(action), spree.fire_admin_order_payment_path(order, payment, e: action),
+                      method: :put, no_text: true, data: action_data,
+                      class: 'btn btn-light btn-sm') if can?(action.to_sym, payment) %>
+              <% end %>
+            <% end %>
+          </span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/spree/admin/suspicious_orders/index.html.erb
+++ b/app/views/spree/admin/suspicious_orders/index.html.erb
@@ -1,0 +1,112 @@
+<% content_for :page_title do %>
+  <%= Spree.t('admin.orders.suspicious_orders') %>
+<% end %>
+
+<%# Simple, always-visible filters kept intentionally small. %>
+<div class="card mb-3">
+  <div class="card-body">
+    <%= search_form_for [:admin, @search], url: spree.admin_suspicious_orders_path, html: { method: :get } do |f| %>
+      <div class="form-row align-items-end">
+        <div class="col-12 col-sm-6 col-lg mb-2 mb-lg-0">
+          <div class="form-group mb-0">
+            <%= f.label :number_cont, Spree.t(:search_order_number) %>
+            <%= f.search_field :number_cont, class: 'form-control' %>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg mb-2 mb-lg-0">
+          <div class="form-group mb-0">
+            <%= f.label :payments_number_cont, Spree.t('admin.orders.payment_number') %>
+            <%= f.search_field :payments_number_cont, class: 'form-control' %>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg mb-2 mb-lg-0">
+          <div class="form-group mb-0">
+            <%= f.label :email_or_phone_number_cont, Spree.t('admin.orders.email_or_phone') %>
+            <%= f.search_field :email_or_phone_number_cont, class: 'form-control' %>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg mb-2 mb-lg-0">
+          <div class="form-group mb-0">
+            <%= f.label :payment_state_eq, Spree.t(:payment_state) %>
+
+            <%= f.select :payment_state_eq,
+                  ::Spree::Order::PAYMENT_STATES.map { |s| [Spree.t("payment_states.#{s}"), s] },
+                  { include_blank: true }, class: 'select2-clear' %>
+          </div>
+        </div>
+        <div class="col-12 col-sm-6 col-lg mb-2 mb-lg-0">
+          <div class="form-group mb-0">
+            <%= f.label :payments_payment_method_id_eq, Spree.t(:payment_method) %>
+            <%= f.select :payments_payment_method_id_eq,
+                  ::Spree::PaymentMethod.pluck(:name, :id),
+                  { include_blank: true }, class: 'select2-clear' %>
+          </div>
+        </div>
+        <div class="col-12 col-lg-auto mb-2 mb-lg-0">
+          <%= button Spree.t(:search), 'search.svg', 'submit', class: 'btn-primary btn-block' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<table class="table" id="listing_suspicious_orders">
+  <thead>
+    <tr>
+      <th><%= Spree.t(:order) %></th>
+      <th><%= Spree.t(:date) %></th>
+      <th><%= Spree.t(:status) %></th>
+      <th><%= Spree.t(:payment_state) %></th>
+      <th class="text-right"><%= Spree.t(:total) %></th>
+      <th class="text-right"><%= Spree.t('admin.orders.outstanding_balance') %></th>
+      <th class="text-right"><%= Spree.t('admin.orders.payments') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @orders.each do |order| %>
+      <% payments_frame_id = "payments-collapse-#{order.id}" %>
+      <tr>
+        <td><%= link_to order.number, spree.edit_admin_order_path(order) %></td>
+        <td><%= pretty_time(order.completed_at) %></td>
+        <td>
+          <span class="badge badge-pill badge-<%= order.state %>">
+            <%= Spree.t("order_state.#{order.state}") %>
+          </span>
+        </td>
+        <td>
+          <span class="badge badge-pill badge-<%= order.payment_state %>">
+            <%= Spree.t("payment_states.#{order.payment_state}") %>
+          </span>
+        </td>
+        <td class="text-right"><%= order.display_total %></td>
+        <td class="text-right"><%= order.display_outstanding_balance %></td>
+        <td class="text-right">
+          <button type="button" data-toggle="collapse" data-target="#<%= payments_frame_id %>"
+                  aria-expanded="false" aria-controls="<%= payments_frame_id %>"
+                  class="btn btn-sm btn-light">
+            <%= Spree.t('admin.orders.payments_count', count: order.payments.size) %>
+            <%= svg_icon(name: 'chevron-down.svg', classes: 'icon ml-1', width: 12, height: 12) %>
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td colspan="7" class="p-0 border-top-0">
+          <div class="collapse" id="<%= payments_frame_id %>">
+            <div class="mb-3 border border-primary rounded-lg overflow-hidden bg-white">
+              <div class="bg-light px-3 py-2 small font-weight-bold text-uppercase text-muted">
+                <%= svg_icon(name: 'receipt.svg', classes: 'icon mr-2', width: 14, height: 14) %>
+                <%= Spree.t('admin.orders.payments_for_order', number: order.number) %>
+              </div>
+              <%= turbo_frame_tag "suspicious_order_#{order.id}_payments",
+                    src: spree.payments_admin_suspicious_order_path(order), loading: 'lazy' do %>
+                <div class="p-3 text-center text-muted"><%= Spree.t(:loading) %>…</div>
+              <% end %>
+            </div>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render 'spree/admin/shared/index_table_options', collection: @orders %>

--- a/app/views/spree/admin/suspicious_orders/payments.html.erb
+++ b/app/views/spree/admin/suspicious_orders/payments.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag "suspicious_order_#{@order.id}_payments" do %>
+  <%= render 'payments_table', order: @order, payments: @payments, check_result: @check_result %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,17 @@ en:
     insufficient_payment_amount_to_cover_the_total: "Payment amount is insufficient to cover the total"
     qr_code: "QR code"
     open_checkout: "Open Checkout"
+    admin:
+      orders:
+        suspicious_orders: "Suspicious Orders"
+        outstanding_balance: "Outstanding Balance"
+        payments: "Payments"
+        payment_number: "Payment Number"
+        email_or_phone: "Email / Phone Number"
+        payments_count:
+          one: "1 Payment"
+          other: "%{count} Payments"
+        payments_for_order: "Payments for %{number}"
     vpago:
       payments:
         check_and_heal: "Auto correct"

--- a/config/locales/km.yml
+++ b/config/locales/km.yml
@@ -6,6 +6,17 @@ spree:
   insufficient_payment_amount_to_cover_the_total: "ចំនួនទឹកប្រាក់នៃការទូទាត់គឺមិនគ្រប់គ្រាន់"
   qr_code: "QR code"
   open_checkout: "Open Checkout"
+  admin:
+    orders:
+      suspicious_orders: "ការបង់ប្រាក់គួរឱ្យសង្ស័យ"
+      outstanding_balance: "សមតុល្យនៅសល់"
+      payments: "ការបង់ប្រាក់"
+      payment_number: "លេខការបង់ប្រាក់"
+      email_or_phone: "អ៊ីមែល / លេខទូរស័ព្ទ"
+      payments_count:
+        one: "ការបង់ប្រាក់ %{count}"
+        other: "ការបង់ប្រាក់ %{count}"
+      payments_for_order: "ការបង់ប្រាក់សម្រាប់ %{number}"
   vpago:
     payments:
       check_and_heal: "កែស្វ័យប្រវត្តិ"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,5 +90,12 @@ Spree::Core::Engine.add_routes do
         post :verify_with_bank
       end
     end
+
+    resources :suspicious_orders, only: [:index] do
+      member do
+        get :payments
+        post 'payments/:payment_number/check_transaction', action: :check_transaction, as: :check_transaction
+      end
+    end
   end
 end


### PR DESCRIPTION
## PR Description

- The problem: The order is complete, but the `payment_state` is `balance_due`, although the payment has been paid (`payment.state` is `pending`). Problem detail: https://github.com/bookmebus/cm-market-app/issues/2804
- The proposed solution is to add a segment where the admin can view to check transactions and process the pending payment if complete (to keep it under control), based on the proposed solution from Bong Thea. 

Add a new tab under the Spree Admin `Orders` group with a clear name `Suspicious Orders`.
By default, this page shows completed orders with a balance due.

https://github.com/user-attachments/assets/a405af8d-3776-47b3-a9de-1cda63913c9d




