### PR TITLE
Close #358 scope backend payments method by vendor

### DIFF
--- a/app/models/vpago/order_decorator.rb
+++ b/app/models/vpago/order_decorator.rb
@@ -64,6 +64,8 @@ module Vpago
 
         payment_methods = if early_adopter?
                             payment_methods.available_on_frontend_for_early_adopter.select { |pm| pm.available_for_order?(self) }
+                          elsif ticket_seller?
+                            payment_methods.available_on_back_end.select { |pm| pm.available_for_order?(self) }
                           else
                             payment_methods.available_on_front_end.select { |pm| pm.available_for_order?(self) }
                           end
@@ -75,6 +77,10 @@ module Vpago
 
     def early_adopter?
       user.present? && user.respond_to?(:early_adopter?) && user.early_adopter?
+    end
+
+    def ticket_seller?
+      user.present? && user.respond_to?(:has_spree_role?) && user.has_spree_role?('ticket_seller')
     end
 
     def tenant_payment_methods

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -186,6 +186,62 @@ RSpec.describe Spree::Order, type: :model do
         expect(order.available_payment_methods).to eq([allowed_method])
       end
     end
+
+    context 'when user is ticket_seller' do
+      let(:store) { instance_double(Spree::Store) }
+      let(:payment_methods_scope) { double('payment_methods_scope') }
+      let(:allowed_method) { instance_double(Spree::PaymentMethod) }
+      let(:blocked_method) { instance_double(Spree::PaymentMethod) }
+
+      before do
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(order).to receive(:early_adopter?).and_return(false)
+        allow(order).to receive(:ticket_seller?).and_return(true)
+        allow(order).to receive(:required_payway_payout?).and_return(false)
+        allow(allowed_method).to receive(:available_for_order?).with(order).and_return(true)
+        allow(blocked_method).to receive(:available_for_order?).with(order).and_return(false)
+      end
+
+      it 'uses back end payment method scope' do
+        expect(payment_methods_scope).to receive(:available_on_back_end).and_return([allowed_method, blocked_method])
+        expect(payment_methods_scope).not_to receive(:available_on_front_end)
+        expect(payment_methods_scope).not_to receive(:available_on_frontend_for_early_adopter)
+
+        expect(order.available_payment_methods).to eq([allowed_method])
+      end
+    end
+
+    context 'when user is both early adopter and ticket_seller' do
+      let(:store) { instance_double(Spree::Store) }
+      let(:payment_methods_scope) { double('payment_methods_scope') }
+      let(:allowed_method) { instance_double(Spree::PaymentMethod) }
+      let(:blocked_method) { instance_double(Spree::PaymentMethod) }
+
+      before do
+        allow(order).to receive(:respond_to?).and_call_original
+        allow(order).to receive(:respond_to?).with(:tenant).and_return(false)
+        allow(order).to receive(:vendor_payment_methods).and_return([])
+        allow(order).to receive(:store).and_return(store)
+        allow(store).to receive(:payment_methods).and_return(payment_methods_scope)
+        allow(order).to receive(:early_adopter?).and_return(true)
+        allow(order).to receive(:ticket_seller?).and_return(true)
+        allow(order).to receive(:required_payway_payout?).and_return(false)
+        allow(allowed_method).to receive(:available_for_order?).with(order).and_return(true)
+        allow(blocked_method).to receive(:available_for_order?).with(order).and_return(false)
+      end
+
+      it 'prioritizes early adopter payment method scope over ticket_seller' do
+        expect(payment_methods_scope).to receive(:available_on_frontend_for_early_adopter).and_return([allowed_method, blocked_method])
+        expect(payment_methods_scope).not_to receive(:available_on_back_end)
+        expect(payment_methods_scope).not_to receive(:available_on_front_end)
+
+        expect(order.available_payment_methods).to eq([allowed_method])
+      end
+    end
   end
 
   describe '#early_adopter?' do


### PR DESCRIPTION
Filter payment methods by ticket seller role

Ticket sellers were seeing the same customer-facing payment methods as everyone else. Now, when the order's user has the ticket_seller role, available_payment_methods returns back-end payment methods instead of front-end ones 

<img width="1512" height="864" alt="image" src="https://github.com/user-attachments/assets/fb729ddd-5754-4b16-a9c9-d2fa9ebe3181" />
